### PR TITLE
Add numerous events and input display example

### DIFF
--- a/examples/input.rs
+++ b/examples/input.rs
@@ -1,0 +1,316 @@
+//! A simple example that demonstrates capturing window and input events.
+use coffee::{Game, Result, Timer};
+use coffee::graphics::{
+    Batch, Color, Font, Gpu, Image, Point, Rectangle, Sprite, 
+    Text, Window, WindowSettings
+};
+use coffee::input;
+use coffee::load::{loading_screen, Join, LoadingScreen, Task};
+
+fn main() -> Result<()> {
+    InputExample::run(WindowSettings {
+        title: String::from("Input Example - Coffee"),
+        size: (720, 240),
+        resizable: false,
+    })
+}
+
+struct Input {
+    cursor_position: Point,
+    mouse_wheel: Point,
+    pressed_keys: Vec<input::KeyCode>,
+    released_keys: Vec<input::KeyCode>,
+    pressed_mouse: Vec<input::MouseButton>,
+    released_mouse: Vec<input::MouseButton>,
+    text_buffer: String,
+}
+
+impl Input {
+    fn new() -> Input {
+        Input {
+            cursor_position: Point::new(0.0, 0.0),
+            mouse_wheel: Point::new(0.0, 0.0),
+            pressed_keys: Vec::new(),
+            released_keys: Vec::new(),
+            pressed_mouse: Vec::new(),
+            released_mouse: Vec::new(),
+            text_buffer: String::new(),
+        }
+    }
+}
+
+struct View {
+    palette: Image,
+    font: Font,
+}
+
+impl View {
+    const COLORS: [Color; 1] = [
+        Color {
+            r: 1.0,
+            g: 0.0,
+            b: 0.0,
+            a: 1.0,
+        },
+    ];
+
+    fn load() -> Task<View> {
+        (
+            Task::using_gpu(|gpu| Image::from_colors(gpu, &Self::COLORS)),
+            Font::load(include_bytes!(
+                "../resources/font/Inconsolata-Regular.ttf"
+            )),
+        )
+            .join()
+            .map(|(palette, font)| View {
+                palette,
+                font,
+            })
+    }
+}
+
+struct InputExample {
+    mouse_x: f32,
+    mouse_y: f32,
+    wheel_x: f32,
+    wheel_y: f32,
+    text_buffer: String,
+    pressed_keys: String,
+    released_keys: String,
+    pressed_mousebuttons: String,
+    released_mousebuttons: String,
+}
+
+impl InputExample {
+
+}
+
+impl Game for InputExample {
+    type View = View;
+    type Input = Input;
+
+    const TICKS_PER_SECOND: u16 = 10;
+
+    fn new(window: &mut Window) -> Result<(InputExample, Self::View, Self::Input)> {
+        let task = Task::stage("Loading font...", View::load());
+
+        let mut loading_screen = loading_screen::ProgressBar::new(window.gpu());
+        let view = loading_screen.run(task, window)?;
+
+        Ok((InputExample{
+                mouse_x: 0.0, 
+                mouse_y: 0.0,
+                wheel_x: 0.0,
+                wheel_y: 0.0,
+                text_buffer: String::with_capacity(256),
+                pressed_keys: String::new(),
+                released_keys: String::new(),
+                pressed_mousebuttons: String::new(),
+                released_mousebuttons: String::new(),
+            }, view, Input::new()))
+    }
+
+    fn on_input(&self, input: &mut Input, event: input::Event) {
+        match event {
+            input::Event::CursorMoved { x, y } => {
+                input.cursor_position = Point::new(x, y);
+            }
+            input::Event::TextInput { character } => {
+                input.text_buffer.push(character);
+            }
+            input::Event::MouseWheel { delta_x, delta_y } => {
+                input.mouse_wheel = Point::new(delta_x, delta_y);
+            }
+            input::Event::KeyboardInput {
+                key_code,
+                state
+            } => {
+                match state {
+                    input::ButtonState::Pressed => input.pressed_keys.push(key_code),
+                    input::ButtonState::Released => input.released_keys.push(key_code),
+                };
+            }
+            input::Event::MouseInput {
+                state,
+                button
+            } => {
+                match state {
+                    input::ButtonState::Pressed => input.pressed_mouse.push(button),
+                    input::ButtonState::Released => input.released_mouse.push(button),
+                };
+            }
+            _ => {}
+        }
+    }
+
+    fn update(&mut self, _view: &Self::View, _window: &Window) {
+    }
+
+    fn interact(&mut self, input: &mut Input, _view: &mut View, _gpu: &mut Gpu) {
+        self.mouse_x = input.cursor_position.x;
+        self.mouse_y = input.cursor_position.y;
+
+        self.wheel_x = input.mouse_wheel.x;
+        self.wheel_y = input.mouse_wheel.y;
+        input.mouse_wheel.x = 0.0;
+        input.mouse_wheel.y = 0.0;
+
+        if !input.text_buffer.is_empty() {
+            for c in input.text_buffer.chars() {
+                match c {
+                    '\u{0008}' => {
+                        self.text_buffer.pop();
+                    }
+                    _ => {
+                        if self.text_buffer.chars().count() < 30 {
+                            self.text_buffer.push_str(&input.text_buffer);
+                        }
+                    }
+                }
+            }
+            input.text_buffer.clear();
+        }
+
+        self.pressed_keys = input.pressed_keys.iter()
+                                 .map(|k| format!("{:?}", k))
+                                 .collect::<Vec<_>>()
+                                 .join(", ");
+
+        self.released_keys = input.released_keys.iter()
+                                 .map(|k| format!("{:?}", k))
+                                 .collect::<Vec<_>>()
+                                 .join(", ");
+
+        input.pressed_keys.clear();
+        input.released_keys.clear();
+
+        self.pressed_mousebuttons = input.pressed_mouse.iter()
+                                 .map(|k| format!("{:?}", k))
+                                 .collect::<Vec<_>>()
+                                 .join(", ");
+
+        self.released_mousebuttons = input.released_mouse.iter()
+                                 .map(|k| format!("{:?}", k))
+                                 .collect::<Vec<_>>()
+                                 .join(", ");
+
+        input.pressed_mouse.clear();
+        input.released_mouse.clear();
+    }
+
+    fn draw(&self, view: &mut Self::View, window: &mut Window, _timer: &Timer) {
+        let mut frame = window.frame();
+        frame.clear(Color::BLACK);
+
+        view.font.add(Text {
+            content: String::from("Text Buffer (type):"),
+            position: Point::new(20.0, frame.height() - 40.0),
+            bounds: (frame.width(), frame.height()),
+            size: 20.0,
+            color: Color::WHITE,
+        });
+
+        view.font.add(Text {
+            content: self.text_buffer.clone(),
+            position: Point::new(280.0, frame.height() - 40.0),
+            bounds: (frame.width(), frame.height()),
+            size: 20.0,
+            color: Color::WHITE,
+        });
+
+        view.font.add(Text {
+            content: String::from("Pressed keys:"),
+            position: Point::new(20.0, 20.0),
+            bounds: (frame.width(), frame.height()),
+            size: 20.0,
+            color: Color::WHITE,
+        });
+
+        view.font.add(Text {
+            content: self.pressed_keys.clone(),
+            position: Point::new(280.0, 20.0),
+            bounds: (frame.width(), frame.height()),
+            size: 20.0,
+            color: Color::from_rgb(0, 255, 0),
+        });
+
+        view.font.add(Text {
+            content: String::from("Released keys:"),
+            position: Point::new(20.0, 50.0),
+            bounds: (frame.width(), frame.height()),
+            size: 20.0,
+            color: Color::WHITE,
+        });
+
+        view.font.add(Text {
+            content: self.released_keys.clone(),
+            position: Point::new(280.0, 50.0),
+            bounds: (frame.width(), frame.height()),
+            size: 20.0,
+            color: Color::from_rgb(255, 0, 0),
+        });
+
+        view.font.add(Text {
+            content: String::from("Mouse wheel scroll:"),
+            position: Point::new(20.0, 80.0),
+            bounds: (frame.width(), frame.height()),
+            size: 20.0,
+            color: Color::WHITE,
+        });
+
+        view.font.add(Text {
+            content: format!("{}, {}", self.wheel_x, self.wheel_y),
+            position: Point::new(280.0, 80.0),
+            bounds: (frame.width(), frame.height()),
+            size: 20.0,
+            color: Color::WHITE,
+        });
+
+        view.font.add(Text {
+            content: String::from("Pressed mouse buttons:"),
+            position: Point::new(20.0, 110.0),
+            bounds: (frame.width(), frame.height()),
+            size: 20.0,
+            color: Color::WHITE,
+        });
+
+        view.font.add(Text {
+            content: self.pressed_mousebuttons.clone(),
+            position: Point::new(280.0, 110.0),
+            bounds: (frame.width(), frame.height()),
+            size: 20.0,
+            color: Color::from_rgb(0, 255, 0),
+        });
+
+        view.font.add(Text {
+            content: String::from("Released mouse buttons:"),
+            position: Point::new(20.0, 140.0),
+            bounds: (frame.width(), frame.height()),
+            size: 20.0,
+            color: Color::WHITE,
+        });
+
+        view.font.add(Text {
+            content: self.released_mousebuttons.clone(),
+            position: Point::new(280.0, 140.0),
+            bounds: (frame.width(), frame.height()),
+            size: 20.0,
+            color: Color::from_rgb(255, 0, 0),
+        });
+
+        view.font.draw(&mut frame);
+
+        let mut batch = Batch::new(view.palette.clone());
+        // Draw a small square at the mouse cursor's position.
+        batch.add(Sprite {
+            source: Rectangle {
+                x: 0,
+                y: 0,
+                width: 6,
+                height: 6,
+            },
+            position: Point::new(self.mouse_x - 3.0, self.mouse_y - 3.0)
+        });
+        batch.draw(Point::new(0.0, 0.0), &mut frame.as_target());
+    }
+}

--- a/src/graphics/window/event.rs
+++ b/src/graphics/window/event.rs
@@ -6,6 +6,7 @@ pub(crate) enum Event {
     Resized(winit::dpi::LogicalSize),
     Input(input::Event),
     CursorMoved(winit::dpi::LogicalPosition),
+    Moved(winit::dpi::LogicalPosition),
 }
 
 pub struct EventLoop(winit::EventsLoop);
@@ -84,12 +85,9 @@ impl EventLoop {
                             input::Event::WindowUnfocused
                         }))
                     }
-                    winit::WindowEvent::Moved(
-                        winit::dpi::LogicalPosition { x, y },
-                    ) => f(Event::Input(input::Event::WindowMoved {
-                        x: x as f32,
-                        y: y as f32,
-                    })),
+                    winit::WindowEvent::Moved(position) => {
+                        f(Event::Moved(position))
+                    }
                     _ => {}
                 },
                 _ => (),

--- a/src/graphics/window/event.rs
+++ b/src/graphics/window/event.rs
@@ -46,15 +46,50 @@ impl EventLoop {
                         state,
                         button,
                     })),
+                    winit::WindowEvent::MouseWheel { delta, .. } => match delta
+                    {
+                        winit::MouseScrollDelta::LineDelta(x, y) => {
+                            f(Event::Input(input::Event::MouseWheel {
+                                delta_x: x,
+                                delta_y: y,
+                            }))
+                        }
+                        _ => {}
+                    },
+
+                    winit::WindowEvent::ReceivedCharacter(codepoint) => {
+                        f(Event::Input(input::Event::TextInput {
+                            character: codepoint,
+                        }))
+                    }
                     winit::WindowEvent::CursorMoved { position, .. } => {
                         f(Event::CursorMoved(position))
                     }
-                    winit::WindowEvent::CloseRequested => {
+                    winit::WindowEvent::CursorEntered { .. } => {
+                        f(Event::Input(input::Event::CursorEntered))
+                    }
+                    winit::WindowEvent::CursorLeft { .. } => {
+                        f(Event::Input(input::Event::CursorLeft))
+                    }
+                    winit::WindowEvent::CloseRequested { .. } => {
                         f(Event::CloseRequested)
                     }
                     winit::WindowEvent::Resized(logical_size) => {
                         f(Event::Resized(logical_size))
                     }
+                    winit::WindowEvent::Focused(focus) => {
+                        f(Event::Input(if focus == true {
+                            input::Event::WindowFocused
+                        } else {
+                            input::Event::WindowUnfocused
+                        }))
+                    }
+                    winit::WindowEvent::Moved(
+                        winit::dpi::LogicalPosition { x, y },
+                    ) => f(Event::Input(input::Event::WindowMoved {
+                        x: x as f32,
+                        y: y as f32,
+                    })),
                     _ => {}
                 },
                 _ => (),

--- a/src/input.rs
+++ b/src/input.rs
@@ -29,6 +29,12 @@ pub enum Event {
         key_code: KeyCode,
     },
 
+    /// Text was entered.
+    TextInput {
+        /// The character entered
+        character: char,
+    },
+
     /// The mouse cursor was moved
     CursorMoved {
         /// The X coordinate of the mouse position
@@ -38,6 +44,12 @@ pub enum Event {
         y: f32,
     },
 
+    /// The mouse cursor entered the game window.
+    CursorEntered,
+
+    /// The mouse cursor left the game window.
+    CursorLeft,
+
     /// A mouse button was pressed or released.
     MouseInput {
         /// The state of the button
@@ -45,5 +57,29 @@ pub enum Event {
 
         /// The button identifier
         button: MouseButton,
+    },
+
+    /// The mouse wheel was scrolled.
+    MouseWheel {
+        /// The number of horizontal lines scrolled
+        delta_x: f32,
+
+        /// The number of vertical lines scrolled
+        delta_y: f32,
+    },
+
+    /// The game window gained focus.
+    WindowFocused,
+
+    /// The game window lost focus.
+    WindowUnfocused,
+
+    /// The game window was moved.
+    WindowMoved {
+        /// The new X coordinate of the window
+        x: f32,
+
+        /// The new Y coordinate of the window
+        y: f32,
     },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,6 +301,17 @@ pub trait Game {
                         },
                     )
                 }
+                window::Event::Moved(logical_position) => {
+                    let position = logical_position.to_physical(window.dpi());
+
+                    game.on_input(
+                        input,
+                        input::Event::WindowMoved {
+                            x: position.x as f32,
+                            y: position.y as f32,
+                        },
+                    )
+                }
                 window::Event::CloseRequested => {
                     if game.on_close_request(input) {
                         *alive = false;


### PR DESCRIPTION
#12 

This exposes the following additional `input::Event` variants: 

- `TextInput`: Triggers on text entry. Contains the character typed as a `char`.
- `CursorEntered`/`CursorLeft`: Triggers when the mouse cursor enters or leaves the game window, respectively.
- `MouseWheel`: Triggers when the mouse wheel is scrolled. Contains the number of horizontal and vertical lines scrolled as `f32`.
- `WindowFocused`/`WindowUnfocused`: Triggers when the game window gains or loses focus, respectively. (This was originally 1 event with a bool in winit; I split it into two to mirror `CursorEntered`/`CursorLeft`.)
- `WindowMoved`: Triggers when the game window is moved. Contains the new X and Y coordinates of the window as `f32`.

The naming will probably need updating to match your personal style.

Besides that, I've added an example that displays inputs, but it's pretty roughly written. If this is something you think might be good to have in the repository, I can take some time to refactor it a bit (like reducing all the label drawing by writing a helper, etc.). Currently it draws a red square under the mouse's position, displays pressed/released mouse buttons/keys, scroll wheel scrolls, and has a text buffer at the bottom to test the text entry event (supporting backspace). It's very likely not idiomatic Rust, either (I'm fairly new to the language), so ultimately it's your call whether you want to keep this or drop it. 

A raw input display-style sample like this may not be suited to your engine, either; since `Game::draw` has no access to `Input`, there's a lot of passing variables from `Game::on_input` to `Input` to `Game::interact` to `Game` and finally to `Game::draw`, so it may be a bit too complex for an example.

Let me know if there are any other events I should implement, names I should change, fields I should expose...