### PR TITLE
Implement font rendering for `wgpu` backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,10 @@ features = ["opengl", "debug"]
 [features]
 default = []
 opengl = ["gfx", "gfx_core", "glutin", "gfx_device_gl", "gfx_window_glutin", "gfx_glyph", "gfx_winit"]
-vulkan = ["wgpu", "wgpu/vulkan"]
-metal = ["wgpu", "wgpu/metal"]
-dx11 = ["wgpu", "wgpu/dx11"]
-dx12 = ["wgpu", "wgpu/dx12"]
+vulkan = ["wgpu", "wgpu/vulkan", "wgpu_glyph"]
+metal = ["wgpu", "wgpu/metal", "wgpu_glyph"]
+dx11 = ["wgpu", "wgpu/dx11", "wgpu_glyph"]
+dx12 = ["wgpu", "wgpu/dx12", "wgpu_glyph"]
 debug = []
 
 [dependencies]
@@ -42,6 +42,7 @@ gfx_winit = { package = "winit", version = "0.19", optional = true }
 
 # wgpu (Vulkan, Metal, D3D)
 wgpu = { version = "0.2", optional = true }
+wgpu_glyph = { version = "0.1", optional = true }
 
 [dev-dependencies]
 # Example dependencies

--- a/src/graphics/backend_gfx/mod.rs
+++ b/src/graphics/backend_gfx/mod.rs
@@ -128,6 +128,8 @@ impl Gpu {
         font: &mut Font,
         target: &TargetView,
         depth: &DepthView,
+        _target_width: u32,
+        _target_height: u32,
     ) {
         font.draw(&mut self.encoder, target, depth);
     }

--- a/src/graphics/backend_wgpu/font.rs
+++ b/src/graphics/backend_wgpu/font.rs
@@ -1,13 +1,43 @@
+use crate::graphics::gpu::TargetView;
 use crate::graphics::Text;
 
 pub struct Font {
-    //glyphs: gfx_glyph::GlyphBrush<'static, gl::Resources, gl::Factory>,
+    glyphs: wgpu_glyph::GlyphBrush<'static>,
 }
 
 impl Font {
-    pub fn from_bytes(_bytes: &'static [u8]) -> Font {
-        Font {}
+    pub fn from_bytes(device: &mut wgpu::Device, bytes: &'static [u8]) -> Font {
+        Font {
+            glyphs: wgpu_glyph::GlyphBrushBuilder::using_font_bytes(bytes)
+                .texture_filter_method(wgpu::FilterMode::Nearest)
+                .build(device),
+        }
     }
 
-    pub fn add(&mut self, _text: Text) {}
+    pub fn add(&mut self, text: Text) {
+        self.glyphs.queue(wgpu_glyph::Section {
+            text: &text.content,
+            screen_position: (text.position.x, text.position.y),
+            scale: wgpu_glyph::Scale {
+                x: text.size,
+                y: text.size,
+            },
+            color: text.color.into(),
+            bounds: text.bounds,
+            ..Default::default()
+        });
+    }
+
+    pub fn draw(
+        &mut self,
+        device: &mut wgpu::Device,
+        encoder: &mut wgpu::CommandEncoder,
+        target: &TargetView,
+        target_width: u32,
+        target_height: u32,
+    ) {
+        self.glyphs
+            .draw_queued(device, encoder, target, target_width, target_height)
+            .expect("Draw font");
+    }
 }

--- a/src/graphics/backend_wgpu/mod.rs
+++ b/src/graphics/backend_wgpu/mod.rs
@@ -98,7 +98,7 @@ impl Gpu {
     }
 
     pub(super) fn upload_font(&mut self, bytes: &'static [u8]) -> Font {
-        Font::from_bytes(bytes)
+        Font::from_bytes(&mut self.device, bytes)
     }
 
     pub(super) fn draw_texture_quads(
@@ -120,9 +120,18 @@ impl Gpu {
 
     pub(super) fn draw_font(
         &mut self,
-        _font: &mut Font,
-        _target: &TargetView,
+        font: &mut Font,
+        target: &TargetView,
         _depth: &DepthView,
+        target_width: u32,
+        target_height: u32,
     ) {
+        font.draw(
+            &mut self.device,
+            &mut self.encoder,
+            target,
+            target_width,
+            target_height,
+        );
     }
 }

--- a/src/graphics/window/frame.rs
+++ b/src/graphics/window/frame.rs
@@ -58,6 +58,8 @@ impl<'a> Frame<'a> {
             font,
             &self.window.surface.target(),
             &self.window.surface.depth(),
+            self.width().round() as u32,
+            self.height().round() as u32,
         );
     }
 }


### PR DESCRIPTION
Fixes #5.

This was pretty straightforward to integrate. I have:

  * Added [`wgpu_glyph`] as a dependency.
  * Implemented `gpu::Font` for the `wgpu_backend`. The implementation is very similar to the `gfx` backend.

The hard part was [`wgpu_glyph`], which still needs some improvements.

Currently, there are differences between `gfx` and `wgpu` font rendering. I suspect it is related to the way we deal (or do not deal) with gamma correction. I will open a new issue to further investigate this.

[`wgpu_glyph`]: https://github.com/hecrj/wgpu_glyph