### PR TITLE
Handle gamma correction properly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ gfx_winit = { package = "winit", version = "0.19", optional = true }
 
 # wgpu (Vulkan, Metal, D3D)
 wgpu = { version = "0.2", optional = true }
-wgpu_glyph = { version = "0.1", optional = true }
+wgpu_glyph = { version = "0.2", optional = true }
 
 [dev-dependencies]
 # Example dependencies

--- a/examples/colors.rs
+++ b/examples/colors.rs
@@ -1,0 +1,89 @@
+use coffee::graphics::{
+    Color, Font, Image, Point, Quad, Rectangle, Text, Window, WindowSettings,
+};
+use coffee::load::{loading_screen, Join, LoadingScreen, Task};
+use coffee::{Game, Result, Timer};
+
+fn main() -> Result<()> {
+    Colors::run(WindowSettings {
+        title: String::from("Colors - Coffee"),
+        size: (1280, 1024),
+        resizable: false,
+    })
+}
+
+struct Colors;
+
+impl Game for Colors {
+    type View = View;
+    type Input = ();
+
+    const TICKS_PER_SECOND: u16 = 10;
+
+    fn new(window: &mut Window) -> Result<(Self, Self::View, Self::Input)> {
+        let load = Task::stage("Loading view...", View::load());
+
+        let mut loading_screen = loading_screen::ProgressBar::new(window.gpu());
+        let view = loading_screen.run(load, window)?;
+
+        Ok((Colors, view, ()))
+    }
+
+    fn update(&mut self, _view: &Self::View, _window: &Window) {}
+
+    fn draw(&self, view: &mut Self::View, window: &mut Window, _timer: &Timer) {
+        let mut frame = window.frame();
+        frame.clear(Color::new(0.5, 0.5, 0.5, 1.0));
+
+        view.palette.draw(
+            Quad {
+                source: Rectangle {
+                    x: 0.0,
+                    y: 0.0,
+                    width: 1.0,
+                    height: 1.0,
+                },
+                position: Point::new(0.0, 0.0),
+                size: (500.0, 500.0),
+            },
+            &mut frame.as_target(),
+        );
+
+        view.font.add(Text {
+            content: String::from("Prussian blue"),
+            position: Point::new(20.0, 500.0),
+            size: 50.0,
+            bounds: (frame.width(), frame.height()),
+            color: View::PRUSSIAN_BLUE,
+        });
+
+        view.font.draw(&mut frame);
+    }
+}
+
+struct View {
+    palette: Image,
+    font: Font,
+}
+
+impl View {
+    const PRUSSIAN_BLUE: Color = Color {
+        r: 0.0,
+        g: 0.1922,
+        b: 0.3255,
+        a: 1.0,
+    };
+
+    fn load() -> Task<View> {
+        (
+            Task::using_gpu(|gpu| {
+                Image::from_colors(gpu, &[Self::PRUSSIAN_BLUE])
+            }),
+            Font::load(include_bytes!(
+                "../resources/font/Inconsolata-Regular.ttf"
+            )),
+        )
+            .join()
+            .map(|(palette, font)| View { palette, font })
+    }
+}

--- a/src/graphics/backend_gfx/font.rs
+++ b/src/graphics/backend_gfx/font.rs
@@ -25,7 +25,7 @@ impl Font {
                 x: text.size,
                 y: text.size,
             },
-            color: text.color.into(),
+            color: text.color.into_linear(),
             bounds: text.bounds,
             ..Default::default()
         });

--- a/src/graphics/backend_gfx/mod.rs
+++ b/src/graphics/backend_gfx/mod.rs
@@ -69,7 +69,8 @@ impl Gpu {
             gfx::format::Srgba8,
         > = gfx::memory::Typed::new(view.clone());
 
-        self.encoder.clear(&typed_render_target, color.into())
+        self.encoder
+            .clear(&typed_render_target, color.into_linear())
     }
 
     fn flush(&mut self) {

--- a/src/graphics/backend_wgpu/font.rs
+++ b/src/graphics/backend_wgpu/font.rs
@@ -10,7 +10,7 @@ impl Font {
         Font {
             glyphs: wgpu_glyph::GlyphBrushBuilder::using_font_bytes(bytes)
                 .texture_filter_method(wgpu::FilterMode::Nearest)
-                .build(device),
+                .build(device, wgpu::TextureFormat::Bgra8UnormSrgb),
         }
     }
 
@@ -22,7 +22,7 @@ impl Font {
                 x: text.size,
                 y: text.size,
             },
-            color: text.color.into(),
+            color: text.color.into_linear(),
             bounds: text.bounds,
             ..Default::default()
         });

--- a/src/graphics/backend_wgpu/mod.rs
+++ b/src/graphics/backend_wgpu/mod.rs
@@ -62,7 +62,7 @@ impl Gpu {
     }
 
     pub(super) fn clear(&mut self, view: &TargetView, color: Color) {
-        let [r, g, b, a]: [f32; 4] = color.into();
+        let [r, g, b, a]: [f32; 4] = color.into_linear();
 
         let _ = self.encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {

--- a/src/graphics/backend_wgpu/pipeline.rs
+++ b/src/graphics/backend_wgpu/pipeline.rs
@@ -111,7 +111,7 @@ impl Pipeline {
                 },
                 primitive_topology: wgpu::PrimitiveTopology::TriangleList,
                 color_states: &[wgpu::ColorStateDescriptor {
-                    format: wgpu::TextureFormat::Bgra8Unorm,
+                    format: wgpu::TextureFormat::Bgra8UnormSrgb,
                     color: wgpu::BlendDescriptor {
                         src_factor: wgpu::BlendFactor::SrcAlpha,
                         dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,

--- a/src/graphics/backend_wgpu/surface.rs
+++ b/src/graphics/backend_wgpu/surface.rs
@@ -130,7 +130,7 @@ fn new_swap_chain(
         size: extent,
         dimension: wgpu::TextureDimension::D2,
         array_size: 1,
-        format: wgpu::TextureFormat::Bgra8Unorm,
+        format: wgpu::TextureFormat::Bgra8UnormSrgb,
         usage: wgpu::TextureUsageFlags::OUTPUT_ATTACHMENT
             | wgpu::TextureUsageFlags::TRANSFER_SRC,
     });

--- a/src/graphics/backend_wgpu/texture.rs
+++ b/src/graphics/backend_wgpu/texture.rs
@@ -174,7 +174,7 @@ fn create_texture_array(
         size: extent,
         array_size: layer_count,
         dimension: wgpu::TextureDimension::D2,
-        format: wgpu::TextureFormat::Bgra8Unorm,
+        format: wgpu::TextureFormat::Bgra8UnormSrgb,
         usage,
     });
 
@@ -220,7 +220,7 @@ fn create_texture_array(
     }
 
     let view = texture.create_view(&wgpu::TextureViewDescriptor {
-        format: wgpu::TextureFormat::Bgra8Unorm,
+        format: wgpu::TextureFormat::Bgra8UnormSrgb,
         dimension: wgpu::TextureViewDimension::D2Array,
         aspect: wgpu::TextureAspectFlags::COLOR,
         base_mip_level: 0,

--- a/src/graphics/color.rs
+++ b/src/graphics/color.rs
@@ -55,6 +55,25 @@ impl Color {
             (self.a * 255.0).round() as u8,
         ]
     }
+
+    pub(crate) fn into_linear(self) -> [f32; 4] {
+        // As described in:
+        // https://en.wikipedia.org/wiki/SRGB#The_reverse_transformation
+        fn linear_component(u: f32) -> f32 {
+            if u < 0.04045 {
+                u / 12.92
+            } else {
+                ((u + 0.055) / 1.055).powf(2.4)
+            }
+        }
+
+        [
+            linear_component(self.r),
+            linear_component(self.g),
+            linear_component(self.b),
+            self.a,
+        ]
+    }
 }
 
 impl From<[u8; 3]> for Color {


### PR DESCRIPTION
Yesterday, when I was implementing #18, I noticed text was rendering differently using `gfx` vs `wgpu`.

Here is how it looked when using OpenGL:

![image](https://user-images.githubusercontent.com/518289/56866924-67b43e80-69df-11e9-868c-9ebc91cffa59.png)

Here is how it looked when using Vulkan:

![image](https://user-images.githubusercontent.com/518289/56866930-7f8bc280-69df-11e9-8a90-4ebd1229283f.png)

It's a subtle difference, but the OpenGL version is way more readable (look at the uppercase `I` glyph). The difference? Gamma correction.

This made me start researching about color spaces and how to deal with them, which almost drove me to insanity... But I _think_ I figured out the problem, and the solution is quite simple.

Monitors display colors in the sRGB color space. Therefore, if you have a framebuffer with a `(0.5, 0.5, 0.5)` color value, it will always display the same grey, independently of the format of the framebuffer.

`wgpu_glyph` stores a cache of glyphs in a texture of alpha values. This value is then combined with the font color in the `wgpu_glyph` fragment shader. Then, the __blending stage__ happens.

The __blending stage__ basically combines the color outputs of the fragment shader with the color of the target buffer. If your buffer is not marked as `Srgb`, then the values from the target buffer will be read as if they were __linear__ and combined with the fragment shader outputs directly. Finally, the combined color will be written directly into the target buffer. Thus, you end up with __linear__ values in your frame buffer, which then are displayed by your monitor __as if they were sRGB__. Bad! This causes grey values to look darker than they should, like you can observe in the Vulkan example above.

However, when the target buffer is marked as `Srgb`, the values will be read as `Srgb` and converted into linear before blending. Additionally, the combined color will be converted back into `Srgb` on write. This is what the OpenGL implementation was doing.

This PR fixes the `wgpu` graphics backend to use `Srgb` buffers for textures and render targets, except for the `SwapChain` which we are currently blitting into. It also fixes font and clear color, by converting the `Color` type (which is sRGB) into linear. I have also added a `colors` example to test that colors are rendering properly in both graphics backends.