### PR TITLE
Make `Font::draw` support a `Target` instead of a `Frame`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,12 +37,12 @@ gfx_core = { version = "0.9", optional = true }
 glutin = { version = "0.20", optional = true }
 gfx_device_gl = { version = "0.16", optional = true }
 gfx_window_glutin = { version = "0.30", optional = true }
-gfx_glyph = { version = "0.14", optional = true }
+gfx_glyph = { version = "0.14", optional = true, path = "../glyph-brush/gfx-glyph" }
 gfx_winit = { package = "winit", version = "0.19", optional = true }
 
 # wgpu (Vulkan, Metal, D3D)
 wgpu = { version = "0.2", optional = true }
-wgpu_glyph = { version = "0.2", optional = true }
+wgpu_glyph = { version = "0.2", optional = true, path = "../wgpu_glyph" }
 
 [dev-dependencies]
 # Example dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,12 +37,12 @@ gfx_core = { version = "0.9", optional = true }
 glutin = { version = "0.20", optional = true }
 gfx_device_gl = { version = "0.16", optional = true }
 gfx_window_glutin = { version = "0.30", optional = true }
-gfx_glyph = { version = "0.14", optional = true, path = "../glyph-brush/gfx-glyph" }
+gfx_glyph = { version = "0.15", optional = true }
 gfx_winit = { package = "winit", version = "0.19", optional = true }
 
 # wgpu (Vulkan, Metal, D3D)
 wgpu = { version = "0.2", optional = true }
-wgpu_glyph = { version = "0.2", optional = true, path = "../wgpu_glyph" }
+wgpu_glyph = { version = "0.3", optional = true }
 
 [dev-dependencies]
 # Example dependencies

--- a/examples/color.rs
+++ b/examples/color.rs
@@ -35,6 +35,8 @@ impl Game for Colors {
         let mut frame = window.frame();
         frame.clear(Color::new(0.5, 0.5, 0.5, 1.0));
 
+        let target = &mut frame.as_target();
+
         view.palette.draw(
             Quad {
                 source: Rectangle {
@@ -46,18 +48,18 @@ impl Game for Colors {
                 position: Point::new(0.0, 0.0),
                 size: (500.0, 500.0),
             },
-            &mut frame.as_target(),
+            target,
         );
 
         view.font.add(Text {
             content: String::from("Prussian blue"),
             position: Point::new(20.0, 500.0),
             size: 50.0,
-            bounds: (frame.width(), frame.height()),
             color: View::PRUSSIAN_BLUE,
+            ..Text::default()
         });
 
-        view.font.draw(&mut frame);
+        view.font.draw(target);
     }
 }
 

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -224,7 +224,7 @@ impl Game for InputExample {
             110.0,
         );
 
-        view.font.draw(&mut frame);
+        view.font.draw(&mut frame.as_target());
 
         // Draw a small square at the mouse cursor's position.
         view.palette.draw(

--- a/examples/particles.rs
+++ b/examples/particles.rs
@@ -188,7 +188,7 @@ impl Game for Particles {
             color: Color::WHITE,
         });
 
-        view.font.draw(&mut frame);
+        view.font.draw(&mut frame.as_target());
     }
 }
 

--- a/src/debug/basic.rs
+++ b/src/debug/basic.rs
@@ -160,7 +160,7 @@ impl Debug {
             self.font.add(text.clone());
         }
 
-        self.font.draw(frame);
+        self.font.draw(&mut frame.as_target());
         self.frames_until_refresh -= 1;
     }
 

--- a/src/graphics/backend_gfx/font.rs
+++ b/src/graphics/backend_gfx/font.rs
@@ -1,6 +1,6 @@
 use gfx_device_gl as gl;
 
-use crate::graphics::gpu::{DepthView, TargetView};
+use crate::graphics::gpu::{TargetView, Transformation};
 use crate::graphics::Text;
 
 pub struct Font {
@@ -35,20 +35,22 @@ impl Font {
         &mut self,
         encoder: &mut gfx::Encoder<gl::Resources, gl::CommandBuffer>,
         target: &TargetView,
-        depth: &DepthView,
+        transformation: Transformation,
     ) {
         let typed_target: gfx::handle::RenderTargetView<
             gl::Resources,
             gfx::format::Srgba8,
         > = gfx::memory::Typed::new(target.clone());
 
-        let typed_depth: gfx::handle::DepthStencilView<
-            gl::Resources,
-            gfx::format::Depth,
-        > = gfx::memory::Typed::new(depth.clone());
-
         self.glyphs
-            .draw_queued(encoder, &typed_target, &typed_depth)
+            .draw_queued_with_transform(
+                transformation.into(),
+                encoder,
+                &typed_target,
+                None,
+                // TODO: Does not compile
+                // Wait for https://github.com/alexheretic/glyph-brush/issues/65
+            )
             .expect("Font draw");
     }
 }

--- a/src/graphics/backend_gfx/font.rs
+++ b/src/graphics/backend_gfx/font.rs
@@ -43,14 +43,9 @@ impl Font {
         > = gfx::memory::Typed::new(target.clone());
 
         self.glyphs
-            .draw_queued_with_transform(
-                transformation.into(),
-                encoder,
-                &typed_target,
-                None,
-                // TODO: Does not compile
-                // Wait for https://github.com/alexheretic/glyph-brush/issues/65
-            )
+            .use_queue()
+            .transform(transformation)
+            .draw(encoder, &typed_target)
             .expect("Font draw");
     }
 }

--- a/src/graphics/backend_gfx/mod.rs
+++ b/src/graphics/backend_gfx/mod.rs
@@ -9,7 +9,7 @@ pub use font::Font;
 pub use pipeline::Instance;
 pub use surface::{winit, Surface};
 pub use texture::Texture;
-pub use types::{DepthView, TargetView};
+pub use types::TargetView;
 
 use gfx::{self, Device};
 use gfx_device_gl as gl;

--- a/src/graphics/backend_gfx/mod.rs
+++ b/src/graphics/backend_gfx/mod.rs
@@ -128,10 +128,8 @@ impl Gpu {
         &mut self,
         font: &mut Font,
         target: &TargetView,
-        depth: &DepthView,
-        _target_width: u32,
-        _target_height: u32,
+        transformation: Transformation,
     ) {
-        font.draw(&mut self.encoder, target, depth);
+        font.draw(&mut self.encoder, target, transformation);
     }
 }

--- a/src/graphics/backend_gfx/surface.rs
+++ b/src/graphics/backend_gfx/surface.rs
@@ -1,13 +1,12 @@
 use gfx_device_gl as gl;
 pub use gfx_winit as winit;
 
-use super::{format, DepthView, Gpu, TargetView};
+use super::{format, Gpu, TargetView};
 use crate::{Error, Result};
 
 pub struct Surface {
     context: glutin::WindowedContext,
     target: TargetView,
-    depth: DepthView,
 }
 
 impl Surface {
@@ -23,7 +22,7 @@ impl Surface {
             .with_pixel_format(24, 8)
             .with_vsync(true);
 
-        let (context, device, factory, target, depth) =
+        let (context, device, factory, target, _depth) =
             gfx_window_glutin::init_raw(
                 builder,
                 gl_builder,
@@ -33,15 +32,7 @@ impl Surface {
             )
             .map_err(|error| Error::WindowCreation(error.to_string()))?;
 
-        Ok((
-            Self {
-                context,
-                target,
-                depth,
-            },
-            device,
-            factory,
-        ))
+        Ok((Self { context, target }, device, factory))
     }
 
     pub fn window(&self) -> &winit::Window {
@@ -52,21 +43,16 @@ impl Surface {
         &self.target
     }
 
-    pub fn depth(&self) -> &DepthView {
-        &self.depth
-    }
-
     pub fn update_viewport(&mut self, _gpu: &mut Gpu) {
         let dimensions = self.target.get_dimensions();
 
-        if let Some((target, depth)) = gfx_window_glutin::update_views_raw(
+        if let Some((target, _depth)) = gfx_window_glutin::update_views_raw(
             &self.context,
             dimensions,
             format::COLOR,
             format::DEPTH,
         ) {
             self.target = target;
-            self.depth = depth;
         }
     }
 

--- a/src/graphics/backend_gfx/types.rs
+++ b/src/graphics/backend_gfx/types.rs
@@ -4,8 +4,6 @@ use super::format;
 
 pub type TargetView = gfx::handle::RawRenderTargetView<gl::Resources>;
 
-pub type DepthView = gfx::handle::RawDepthStencilView<gl::Resources>;
-
 pub type RawTexture = gfx::handle::RawTexture<gl::Resources>;
 
 pub type ShaderResource =

--- a/src/graphics/backend_wgpu/font.rs
+++ b/src/graphics/backend_wgpu/font.rs
@@ -1,5 +1,5 @@
 use crate::graphics::gpu::TargetView;
-use crate::graphics::Text;
+use crate::graphics::{Text, Transformation};
 
 pub struct Font {
     glyphs: wgpu_glyph::GlyphBrush<'static>,
@@ -33,11 +33,15 @@ impl Font {
         device: &mut wgpu::Device,
         encoder: &mut wgpu::CommandEncoder,
         target: &TargetView,
-        target_width: u32,
-        target_height: u32,
+        transformation: Transformation,
     ) {
         self.glyphs
-            .draw_queued(device, encoder, target, target_width, target_height)
+            .draw_queued_with_transform(
+                transformation.into(),
+                device,
+                encoder,
+                target,
+            )
             .expect("Draw font");
     }
 }

--- a/src/graphics/backend_wgpu/mod.rs
+++ b/src/graphics/backend_wgpu/mod.rs
@@ -8,7 +8,7 @@ pub use font::Font;
 pub use pipeline::Instance;
 pub use surface::{winit, Surface};
 pub use texture::Texture;
-pub use types::{DepthView, TargetView};
+pub use types::TargetView;
 
 use crate::graphics::{Color, Transformation};
 use crate::{Error, Result};
@@ -122,16 +122,8 @@ impl Gpu {
         &mut self,
         font: &mut Font,
         target: &TargetView,
-        _depth: &DepthView,
-        target_width: u32,
-        target_height: u32,
+        transformation: Transformation,
     ) {
-        font.draw(
-            &mut self.device,
-            &mut self.encoder,
-            target,
-            target_width,
-            target_height,
-        );
+        font.draw(&mut self.device, &mut self.encoder, target, transformation);
     }
 }

--- a/src/graphics/backend_wgpu/surface.rs
+++ b/src/graphics/backend_wgpu/surface.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use super::{DepthView, Gpu, TargetView};
+use super::{Gpu, TargetView};
 pub use wgpu::winit;
 
 pub struct Surface {
@@ -39,10 +39,6 @@ impl Surface {
 
     pub fn target(&self) -> &TargetView {
         &self.target
-    }
-
-    pub fn depth(&self) -> &DepthView {
-        &()
     }
 
     pub fn update_viewport(&mut self, gpu: &mut Gpu) {

--- a/src/graphics/backend_wgpu/types.rs
+++ b/src/graphics/backend_wgpu/types.rs
@@ -1,5 +1,3 @@
 use std::rc::Rc;
 
 pub type TargetView = Rc<wgpu::TextureView>;
-
-pub type DepthView = ();

--- a/src/graphics/font.rs
+++ b/src/graphics/font.rs
@@ -1,5 +1,5 @@
 use crate::graphics::gpu;
-use crate::graphics::{Frame, Gpu, Text};
+use crate::graphics::{Gpu, Target, Text};
 use crate::load::Task;
 use crate::Result;
 
@@ -26,13 +26,11 @@ impl Font {
         self.0.add(text)
     }
 
-    /// Render and flush all the text added to this font.
-    ///
-    /// As of now, [`Font`] can only draw on-screen. This limitation should be
-    /// easy to tackle in the near future.
+    /// Render and flush all the text added to this [`Font`].
     ///
     /// [`Font`]: struct.Font.html
-    pub fn draw(&mut self, frame: &mut Frame) {
-        frame.draw_font(&mut self.0)
+    #[inline]
+    pub fn draw(&mut self, target: &mut Target) {
+        target.draw_font(&mut self.0)
     }
 }

--- a/src/graphics/target.rs
+++ b/src/graphics/target.rs
@@ -1,4 +1,4 @@
-use crate::graphics::gpu::{Gpu, Instance, TargetView, Texture};
+use crate::graphics::gpu::{Font, Gpu, Instance, TargetView, Texture};
 use crate::graphics::{Color, Transformation};
 
 /// A rendering target.
@@ -103,6 +103,10 @@ impl<'a> Target<'a> {
             &self.view,
             &self.transformation,
         );
+    }
+
+    pub(in crate::graphics) fn draw_font(&mut self, font: &mut Font) {
+        self.gpu.draw_font(font, &self.view, self.transformation);
     }
 }
 

--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -1,3 +1,5 @@
+use std::f32;
+
 use crate::graphics::{Color, Point};
 
 /// A section of text.
@@ -17,4 +19,16 @@ pub struct Text {
 
     /// Text color.
     pub color: Color,
+}
+
+impl Default for Text {
+    fn default() -> Text {
+        Text {
+            content: String::from(""),
+            position: Point::new(0.0, 0.0),
+            bounds: (f32::INFINITY, f32::INFINITY),
+            size: 16.0,
+            color: Color::BLACK,
+        }
+    }
 }

--- a/src/graphics/window/frame.rs
+++ b/src/graphics/window/frame.rs
@@ -1,6 +1,6 @@
 use super::Window;
 
-use crate::graphics::{gpu, Color, Target};
+use crate::graphics::{Color, Target};
 
 /// The next frame of your game.
 ///
@@ -51,15 +51,5 @@ impl<'a> Frame<'a> {
     /// [`Color`]: struct.Color.html
     pub fn clear(&mut self, color: Color) {
         self.as_target().clear(color);
-    }
-
-    pub(in crate::graphics) fn draw_font(&mut self, font: &mut gpu::Font) {
-        self.window.gpu.draw_font(
-            font,
-            &self.window.surface.target(),
-            &self.window.surface.depth(),
-            self.width().round() as u32,
-            self.height().round() as u32,
-        );
     }
 }

--- a/src/load/loading_screen.rs
+++ b/src/load/loading_screen.rs
@@ -201,6 +201,6 @@ impl LoadingScreen for ProgressBar {
             color: graphics::Color::WHITE,
         });
 
-        self.font.draw(&mut frame);
+        self.font.draw(&mut frame.as_target());
     }
 }


### PR DESCRIPTION
Fixes #24.

  * [x] https://github.com/alexheretic/glyph-brush/pull/66
  * [x] New `gfx_glyph` release
  * [x] New `wgpu_glyph` release
  * [x] Integration

## Changed
  * Trait `Default` for `Text` was implemented.
  * `Font::draw` now supports a `Target` instead of a `Frame`.

