### PR TITLE
Show time spent in `Debug::draw` in debug view

### DIFF
--- a/src/debug/basic.rs
+++ b/src/debug/basic.rs
@@ -29,6 +29,8 @@ pub struct Debug {
     update_durations: TimeBuffer,
     draw_start: time::Instant,
     draw_durations: TimeBuffer,
+    debug_start: time::Instant,
+    debug_durations: TimeBuffer,
     text: Vec<graphics::Text>,
     draw_rate: u16,
     frames_until_refresh: u16,
@@ -52,6 +54,8 @@ impl Debug {
             update_durations: TimeBuffer::new(200),
             draw_start: now,
             draw_durations: TimeBuffer::new(200),
+            debug_start: now,
+            debug_durations: TimeBuffer::new(200),
             text: Vec::new(),
             draw_rate,
             frames_until_refresh: 0,
@@ -144,6 +148,22 @@ impl Debug {
         self.frames_until_refresh = 0;
     }
 
+    pub(crate) fn debug_started(&mut self) {
+        self.debug_start = time::Instant::now();
+    }
+
+    pub(crate) fn debug_finished(&mut self) {
+        self.debug_durations
+            .push(time::Instant::now() - self.debug_start);
+    }
+
+    /// Get the average time spent running [`Game::debug`].
+    ///
+    /// [`Game::debug`]: trait.Game.html#tymethod.debug
+    pub fn debug_duration(&self) -> time::Duration {
+        self.draw_durations.average()
+    }
+
     pub(crate) fn is_enabled(&self) -> bool {
         self.enabled
     }
@@ -182,6 +202,7 @@ impl Debug {
             ("Interact:", self.interact_duration, None),
             ("Update:", self.update_durations.average(), None),
             ("Draw:", self.draw_durations.average(), None),
+            ("Debug:", self.debug_durations.average(), None),
             ("Frame:", frame_duration, Some(fps.to_string() + " fps")),
         ];
 

--- a/src/debug/null.rs
+++ b/src/debug/null.rs
@@ -13,24 +13,19 @@ impl Debug {
     }
 
     pub(crate) fn loading_started(&mut self) {}
-
     pub(crate) fn loading_finished(&mut self) {}
-
     pub(crate) fn frame_started(&mut self) {}
     pub(crate) fn frame_finished(&mut self) {}
-
     pub(crate) fn interact_started(&mut self) {}
-
     pub(crate) fn interact_finished(&mut self) {}
-
     pub(crate) fn update_started(&mut self) {}
-
     pub(crate) fn update_finished(&mut self) {}
-
     pub(crate) fn draw_started(&mut self) {}
-
     pub(crate) fn draw_finished(&mut self) {}
+    pub(crate) fn debug_started(&mut self) {}
+    pub(crate) fn debug_finished(&mut self) {}
 
+    #[allow(dead_code)]
     pub(crate) fn toggle(&mut self) {}
 
     pub(crate) fn is_enabled(&self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,7 +361,9 @@ pub trait Game {
             debug.draw_finished();
 
             if debug.is_enabled() {
+                debug.debug_started();
                 game.debug(input, view, window, &mut debug);
+                debug.debug_finished();
             }
 
             window.swap_buffers();


### PR DESCRIPTION
I think this will be important once we implement #17.

Here is how it looks now:
![image](https://user-images.githubusercontent.com/518289/57078167-08f80900-6cee-11e9-9d36-fdf3c8cc4a22.png)
