### PR TITLE
Fullscreen support

### DIFF
--- a/examples/color.rs
+++ b/examples/color.rs
@@ -9,6 +9,7 @@ fn main() -> Result<()> {
         title: String::from("Color - Coffee"),
         size: (1280, 1024),
         resizable: false,
+        fullscreen: false,
     })
 }
 

--- a/examples/color.rs
+++ b/examples/color.rs
@@ -1,5 +1,6 @@
 use coffee::graphics::{
-    Color, Font, Image, Point, Quad, Rectangle, Text, Window, WindowSettings,
+    Color, Font, Frame, Image, Point, Quad, Rectangle, Text, Window,
+    WindowSettings,
 };
 use coffee::load::{loading_screen, Join, LoadingScreen, Task};
 use coffee::{Game, Result, Timer};
@@ -32,8 +33,7 @@ impl Game for Colors {
 
     fn update(&mut self, _view: &Self::View, _window: &Window) {}
 
-    fn draw(&self, view: &mut Self::View, window: &mut Window, _timer: &Timer) {
-        let mut frame = window.frame();
+    fn draw(&self, view: &mut Self::View, frame: &mut Frame, _timer: &Timer) {
         frame.clear(Color::new(0.5, 0.5, 0.5, 1.0));
 
         let target = &mut frame.as_target();

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -14,6 +14,7 @@ fn main() -> Result<()> {
         title: String::from("Input - Coffee"),
         size: (720, 240),
         resizable: false,
+        fullscreen: false,
     })
 }
 

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -2,7 +2,7 @@
 use std::collections::HashSet;
 
 use coffee::graphics::{
-    Color, Font, Gpu, Image, Point, Quad, Rectangle, Text, Vector, Window,
+    Color, Font, Frame, Image, Point, Quad, Rectangle, Text, Vector, Window,
     WindowSettings,
 };
 use coffee::input;
@@ -139,7 +139,7 @@ impl Game for InputExample {
         &mut self,
         input: &mut Input,
         _view: &mut View,
-        _gpu: &mut Gpu,
+        _window: &mut Window,
     ) {
         self.cursor_position = input.cursor_position;
         self.mouse_wheel = input.mouse_wheel;
@@ -165,8 +165,7 @@ impl Game for InputExample {
         }
     }
 
-    fn draw(&self, view: &mut Self::View, window: &mut Window, _timer: &Timer) {
-        let mut frame = window.frame();
+    fn draw(&self, view: &mut Self::View, frame: &mut Frame, _timer: &Timer) {
         frame.clear(Color::BLACK);
 
         // This closure simplifies some of the boilerplate.

--- a/examples/particles.rs
+++ b/examples/particles.rs
@@ -18,6 +18,7 @@ fn main() -> Result<()> {
         title: String::from("Particles - Coffee"),
         size: (1280, 1024),
         resizable: false,
+        fullscreen: false,
     })
 }
 
@@ -110,6 +111,9 @@ impl Game for Particles {
                 input::KeyCode::I => {
                     view.interpolate = !view.interpolate;
                 }
+                input::KeyCode::F => {
+                    view.toggle_fullscreen = true;
+                }
                 _ => {}
             }
         }
@@ -137,6 +141,11 @@ impl Game for Particles {
     }
 
     fn draw(&self, view: &mut View, window: &mut Window, timer: &Timer) {
+        if view.toggle_fullscreen {
+            window.toggle_fullscreen();
+            view.toggle_fullscreen = false;
+        }
+
         let mut frame = window.frame();
         frame.clear(Color::BLACK);
 
@@ -228,6 +237,7 @@ struct View {
     batch: Batch,
     font: Font,
     interpolate: bool,
+    toggle_fullscreen: bool,
 }
 
 impl View {
@@ -288,6 +298,7 @@ impl View {
                 batch: Batch::new(palette),
                 font,
                 interpolate: true,
+                toggle_fullscreen: false,
             })
     }
 

--- a/examples/particles.rs
+++ b/examples/particles.rs
@@ -6,7 +6,7 @@ use rayon::prelude::*;
 use std::{thread, time};
 
 use coffee::graphics::{
-    Batch, Color, Font, Gpu, Image, Point, Rectangle, Sprite, Text, Vector,
+    Batch, Color, Font, Frame, Image, Point, Rectangle, Sprite, Text, Vector,
     Window, WindowSettings,
 };
 use coffee::input;
@@ -99,7 +99,12 @@ impl Game for Particles {
         }
     }
 
-    fn interact(&mut self, input: &mut Input, view: &mut View, _gpu: &mut Gpu) {
+    fn interact(
+        &mut self,
+        input: &mut Input,
+        view: &mut View,
+        window: &mut Window,
+    ) {
         self.gravity_centers[0] = input.cursor_position;
 
         for point in &input.points_clicked {
@@ -112,7 +117,7 @@ impl Game for Particles {
                     view.interpolate = !view.interpolate;
                 }
                 input::KeyCode::F => {
-                    view.toggle_fullscreen = true;
+                    window.toggle_fullscreen();
                 }
                 _ => {}
             }
@@ -140,13 +145,7 @@ impl Game for Particles {
         });
     }
 
-    fn draw(&self, view: &mut View, window: &mut Window, timer: &Timer) {
-        if view.toggle_fullscreen {
-            window.toggle_fullscreen();
-            view.toggle_fullscreen = false;
-        }
-
-        let mut frame = window.frame();
+    fn draw(&self, view: &mut View, frame: &mut Frame, timer: &Timer) {
         frame.clear(Color::BLACK);
 
         // Draw particles all at once!
@@ -237,7 +236,6 @@ struct View {
     batch: Batch,
     font: Font,
     interpolate: bool,
-    toggle_fullscreen: bool,
 }
 
 impl View {
@@ -298,7 +296,6 @@ impl View {
                 batch: Batch::new(palette),
                 font,
                 interpolate: true,
-                toggle_fullscreen: false,
             })
     }
 

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -40,7 +40,7 @@
 //!
 //! ```
 //! use coffee::{Game, Timer};
-//! use coffee::graphics::{Window, Color};
+//! use coffee::graphics::{Color, Frame, Window};
 //! # use coffee::Result;
 //! # use coffee::graphics::Gpu;
 //! #
@@ -59,17 +59,16 @@
 //!     // ...
 //!
 //! #   fn interact(&mut self, _input: &mut Self::Input,
-//! #              _view: &mut Self::View, _gpu: &mut Gpu) {}
+//! #              _view: &mut Self::View, _window: &mut Window) {}
 //! #
 //! #   fn update(&mut self, _view: &Self::View, window: &Window) {}
 //! #
 //!     fn draw(
 //!         &self,
 //!         _view: &mut Self::View,
-//!         window: &mut Window,
+//!         frame: &mut Frame,
 //!         _timer: &Timer,
 //!     ) {
-//!         let mut frame = window.frame();
 //!         frame.clear(Color::BLACK);
 //!
 //!         // Use your resources here...

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -35,8 +35,8 @@
 //! types like [`Image`], [`Font`], [`TextureArray`], etc.
 //!
 //! # Getting started
-//! You should probably start your [`Game::draw`] implementation by getting a
-//! [`Frame`] and clearing it:
+//! You should probably start your [`Game::draw`] implementation by clearing
+//! the provided [`Frame`]:
 //!
 //! ```
 //! use coffee::{Game, Timer};

--- a/src/graphics/transformation.rs
+++ b/src/graphics/transformation.rs
@@ -60,9 +60,9 @@ impl Transformation {
     /// You can use this to rotate your camera, for example.
     /// Note: Rotation is in radians.
     pub fn rotate(rotation: f32) -> Transformation {
-        Transformation(nalgebra::Matrix4::new_rotation(
-            nalgebra::Vector3::new(0.0, 0.0, rotation)
-        ))
+        Transformation(nalgebra::Matrix4::new_rotation(nalgebra::Vector3::new(
+            0.0, 0.0, rotation,
+        )))
     }
 }
 

--- a/src/graphics/window/frame.rs
+++ b/src/graphics/window/frame.rs
@@ -1,6 +1,6 @@
 use super::Window;
 
-use crate::graphics::{Color, Target};
+use crate::graphics::{Color, Gpu, Target};
 
 /// The next frame of your game.
 ///
@@ -21,6 +21,15 @@ pub struct Frame<'a> {
 impl<'a> Frame<'a> {
     pub(crate) fn new(window: &mut Window) -> Frame {
         Frame { window }
+    }
+
+    /// Get the [`Gpu`] linked to the [`Window`] of this [`Frame`].
+    ///
+    /// [`Gpu`]: struct.Gpu.html
+    /// [`Window`]: struct.Window.html
+    /// [`Frame`]: struct.Frame.html
+    pub fn gpu(&mut self) -> &mut Gpu {
+        self.window.gpu()
     }
 
     /// Get the width of the frame.

--- a/src/graphics/window/mod.rs
+++ b/src/graphics/window/mod.rs
@@ -21,6 +21,7 @@ pub struct Window {
     surface: gpu::Surface,
     width: f32,
     height: f32,
+    is_fullscreen: bool,
 }
 
 impl Window {
@@ -38,8 +39,12 @@ impl Window {
 
         settings.size = (width, height);
 
-        let (gpu, surface) =
-            Gpu::for_window(settings.into_builder(), event_loop.raw())?;
+        let is_fullscreen = settings.fullscreen;
+
+        let (gpu, surface) = Gpu::for_window(
+            settings.into_builder(event_loop.raw()),
+            event_loop.raw(),
+        )?;
 
         let window = surface.window();
 
@@ -55,6 +60,7 @@ impl Window {
             .unwrap_or((width as f32, height as f32));
 
         Ok(Window {
+            is_fullscreen,
             gpu,
             surface,
             width,
@@ -76,6 +82,23 @@ impl Window {
     /// [`Window`]: struct.Window.html
     pub fn frame(&mut self) -> Frame {
         Frame::new(self)
+    }
+
+    /// Toggles the [`Window`]'s fullscreen state
+    ///
+    /// [`Window`]: struct.Window.html
+    pub fn toggle_fullscreen(&mut self) {
+        let window = self.surface.window();
+
+        let monitor = if self.is_fullscreen {
+            None
+        } else {
+            Some(window.get_primary_monitor())
+        };
+
+        window.set_fullscreen(monitor);
+
+        self.is_fullscreen = !self.is_fullscreen;
     }
 
     /// Get the width of the [`Window`].

--- a/src/graphics/window/mod.rs
+++ b/src/graphics/window/mod.rs
@@ -80,7 +80,7 @@ impl Window {
     ///
     /// [`Frame`]: struct.Frame.html
     /// [`Window`]: struct.Window.html
-    pub fn frame(&mut self) -> Frame {
+    pub(crate) fn frame(&mut self) -> Frame {
         Frame::new(self)
     }
 

--- a/src/graphics/window/mod.rs
+++ b/src/graphics/window/mod.rs
@@ -84,7 +84,7 @@ impl Window {
         Frame::new(self)
     }
 
-    /// Toggles the [`Window`]'s fullscreen state
+    /// Toggles the [`Window`]'s fullscreen state.
     ///
     /// [`Window`]: struct.Window.html
     pub fn toggle_fullscreen(&mut self) {

--- a/src/graphics/window/settings.rs
+++ b/src/graphics/window/settings.rs
@@ -9,12 +9,24 @@ pub struct Settings {
     /// A target size for the window.
     pub size: (u32, u32),
 
-    /// Defines whether if the window should be resizable.
+    /// Defines whether or not the window should be resizable.
     pub resizable: bool,
+
+    /// Defines whether or not the window should start fullscreen.
+    pub fullscreen: bool,
 }
 
 impl Settings {
-    pub(super) fn into_builder(self) -> winit::WindowBuilder {
+    pub(super) fn into_builder(
+        self,
+        events_loop: &winit::EventsLoop,
+    ) -> winit::WindowBuilder {
+        let monitor = if self.fullscreen {
+            Some(events_loop.get_primary_monitor())
+        } else {
+            None
+        };
+
         winit::WindowBuilder::new()
             .with_title(self.title)
             .with_dimensions(winit::dpi::LogicalSize {
@@ -22,5 +34,6 @@ impl Settings {
                 height: self.size.1 as f64,
             })
             .with_resizable(self.resizable)
+            .with_fullscreen(monitor)
     }
 }

--- a/src/graphics/window/settings.rs
+++ b/src/graphics/window/settings.rs
@@ -12,7 +12,7 @@ pub struct Settings {
     /// Defines whether or not the window should be resizable.
     pub resizable: bool,
 
-    /// Defines whether or not the window should start fullscreen.
+    /// Defines whether or not the window should start in fullscreen mode.
     pub fullscreen: bool,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@
 //!         title: String::from("A caffeinated game"),
 //!         size: (1280, 1024),
 //!         resizable: true,
+//!         fullscreen: false,
 //!     })
 //! }
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,8 @@ pub trait Game {
     /// to keep your view updated every frame in order to offer a smooth user
     /// experience independently of the [`TICKS_PER_SECOND`] setting.
     ///
-    /// You can access the GPU if, as a consequence of the interaction, you need
+    /// You can access the [`Window`]. For instance, you may want to toggle
+    /// fullscreen mode based on some input, or maybe access the [`Gpu`]
     /// to prepare some assets before rendering.
     ///
     /// By default, it does nothing.
@@ -212,6 +213,8 @@ pub trait Game {
     /// [`Input`]: #associatedtype.Input
     /// [`update`]: #tymethod.update
     /// [`TICKS_PER_SECOND`]: #associatedconstant.TICKS_PER_SECOND
+    /// [`Window`]: graphics/struct.Window.html
+    /// [`Gpu`]: graphics/struct.Gpu.html
     fn interact(
         &mut self,
         _input: &mut Self::Input,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //!
 //! ```no_run
 //! use coffee::{Game, Result, Timer};
-//! use coffee::graphics::{Color, Window, WindowSettings};
+//! use coffee::graphics::{Color, Frame, Window, WindowSettings};
 //!
 //! fn main() -> Result<()> {
 //!     MyGame::run(WindowSettings {
@@ -53,9 +53,8 @@
 //!         // Update your game here
 //!     }
 //!
-//!     fn draw(&self, _view: &mut Self::View, window: &mut Window, _timer: &Timer) {
+//!     fn draw(&self, _view: &mut Self::View, frame: &mut Frame, _timer: &Timer) {
 //!         // Clear the current frame
-//!         let mut frame = window.frame();
 //!         frame.clear(Color::BLACK);
 //!
 //!         // Draw your game here. Check out the `graphics` module!
@@ -169,7 +168,7 @@ pub trait Game {
     fn draw(
         &self,
         view: &mut Self::View,
-        window: &mut graphics::Window,
+        frame: &mut graphics::Frame,
         timer: &Timer,
     );
 
@@ -217,7 +216,7 @@ pub trait Game {
         &mut self,
         _input: &mut Self::Input,
         _view: &mut Self::View,
-        _gpu: &mut graphics::Gpu,
+        _window: &mut graphics::Window,
     ) {
     }
 
@@ -321,7 +320,7 @@ pub trait Game {
                     window.resize(new_size);
                 }
             });
-            game.interact(input, view, window.gpu());
+            game.interact(input, view, window);
             debug.interact_finished();
         }
 
@@ -358,7 +357,7 @@ pub trait Game {
             }
 
             debug.draw_started();
-            game.draw(view, window, &timer);
+            game.draw(view, &mut window.frame(), &timer);
             debug.draw_finished();
 
             if debug.is_enabled() {

--- a/src/load/loading_screen.rs
+++ b/src/load/loading_screen.rs
@@ -31,7 +31,7 @@ use crate::Result;
 /// use coffee::load::loading_screen::ProgressBar;
 /// use coffee::graphics::Window;
 /// # use coffee::Timer;
-/// # use coffee::graphics::Gpu;
+/// # use coffee::graphics::{Frame, Gpu};
 /// #
 /// # struct State;
 /// # impl State {
@@ -75,10 +75,8 @@ use crate::Result;
 ///     }
 ///
 ///     // ...
-///     # fn interact(&mut self, _input: &mut Self::Input,
-///     #             _view: &mut Self::View, _gpu: &mut Gpu) {}
 ///     # fn update(&mut self, _view: &View, window: &Window) {}
-///     # fn draw(&self, _view: &mut Self::View, _window: &mut Window,
+///     # fn draw(&self, _view: &mut Self::View, _frame: &mut Frame,
 ///     #         _timer: &Timer) {}
 /// }
 /// ```


### PR DESCRIPTION
Implements and closes #23.

Adds a `Window::toggle_fullscreen` method as well as adding a `fullscreen` attribute to `Settings` in case a user wants their game to start in fullscreen mode.

Additionally, the ability to toggle between fullscreen mode and windowed mode via the 'F' key is added to the 'particles' example.