### PR TITLE
`Canvas::draw` is now generic

### DIFF
--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -65,10 +65,13 @@ impl Canvas {
     ///
     /// [`Canvas`]: struct.Canvas.html
     /// [`Target`]: struct.Target.html
-    pub fn draw<T: IntoQuad>(&self, quad: T, target: &mut Target, x_unit: f32, y_unit: f32) {
+    pub fn draw<Q: IntoQuad>(&self, quad: Q, target: &mut Target) {
         target.draw_texture_quads(
             &self.drawable.texture(),
-            &[gpu::Instance::from(quad.into_quad(x_unit, y_unit))],
+            &[gpu::Instance::from(quad.into_quad(
+                1.0 / self.width() as f32,
+                1.0 / self.height() as f32
+            ))],
         );
     }
 }

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -1,5 +1,5 @@
 use crate::graphics::gpu::{self, texture, Gpu};
-use crate::graphics::{Quad, Target};
+use crate::graphics::{Target, IntoQuad};
 use crate::load::Task;
 use crate::Result;
 
@@ -65,10 +65,12 @@ impl Canvas {
     ///
     /// [`Canvas`]: struct.Canvas.html
     /// [`Target`]: struct.Target.html
-    pub fn draw(&self, quad: Quad, target: &mut Target) {
+    pub fn draw<T: IntoQuad>(&self, quad: T, target: &mut Target, x_unit: f32, y_unit: f32) {
+        let converted_quad = quad.into_quad(x_unit, y_unit);
+
         target.draw_texture_quads(
             &self.drawable.texture(),
-            &[gpu::Instance::from(quad)],
+            &[gpu::Instance::from(converted_quad)],
         );
     }
 }

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -66,11 +66,9 @@ impl Canvas {
     /// [`Canvas`]: struct.Canvas.html
     /// [`Target`]: struct.Target.html
     pub fn draw<T: IntoQuad>(&self, quad: T, target: &mut Target, x_unit: f32, y_unit: f32) {
-        let converted_quad = quad.into_quad(x_unit, y_unit);
-
         target.draw_texture_quads(
             &self.drawable.texture(),
-            &[gpu::Instance::from(converted_quad)],
+            &[gpu::Instance::from(quad.into_quad(x_unit, y_unit))],
         );
     }
 }


### PR DESCRIPTION
Implements and resolves #21.

Uses `width` and `height` methods of [`Canvas`](https://github.com/hecrj/coffee/blob/56ff3b4e992013b2438cf3b9c46fd5cf606e9d13/src/graphics/canvas.rs#L12) in order to convert absolute to relative coordinates, as in [`Image::draw`](https://github.com/hecrj/coffee/blob/56ff3b4e992013b2438cf3b9c46fd5cf606e9d13/src/graphics/image.rs#L103).