### PR TITLE
[WIP] Test SPIR-V differences on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
 cache: cargo
 before_install:
   - sudo apt-get update
-  - sudo apt-get install -y glslang
+  - sudo apt-get install -y glslang-tools
 matrix:
   allow_failures:
     - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
   allow_failures:
     - rust: nightly
   fast_finish: true
-  script:
+script:
   - chmod +x spirvtest && ./spirvtest
   - cargo test --verbose --features opengl
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cargo test --verbose --features vulkan --release; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,14 @@ os:
   - osx
   - windows
 cache: cargo
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install -y glslang
 matrix:
   allow_failures:
     - rust: nightly
   fast_finish: true
-script:
+  script:
+  - chmod +x spirvtest && ./spirvtest
   - cargo test --verbose --features opengl
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cargo test --verbose --features vulkan --release; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,15 @@ os:
   - windows
 cache: cargo
 before_install:
-  - sudo apt-get update
-  - sudo apt-get install -y glslang-tools
+  - |
+    mkdir glslang
+    cd glslang
+    wget https://github.com/KhronosGroup/glslang/releases/download/master-tot/glslang-master-linux-Release.zip
+    unzip -u -q glslang-master-linux-Release.zip
+    cd ..
+    export PATH=${TRAVIS_BUILD_DIR}/glslang/bin:$PATH
+    glslangValidator --version
+
 matrix:
   allow_failures:
     - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ matrix:
     - rust: nightly
   fast_finish: true
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; chmod +x spirvtest && ./spirvtest; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then chmod +x spirvtest && ./spirvtest; fi
   - cargo test --verbose --features opengl
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cargo test --verbose --features vulkan --release; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,15 @@ os:
 cache: cargo
 before_install:
   - |
-    mkdir glslang
-    cd glslang
-    wget https://github.com/KhronosGroup/glslang/releases/download/master-tot/glslang-master-linux-Release.zip
-    unzip -u -q glslang-master-linux-Release.zip
-    cd ..
-    export PATH=${TRAVIS_BUILD_DIR}/glslang/bin:$PATH
-    glslangValidator --version
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      mkdir glslang
+      cd glslang
+      wget https://github.com/KhronosGroup/glslang/releases/download/master-tot/glslang-master-linux-Release.zip
+      unzip -u -q glslang-master-linux-Release.zip
+      cd ..
+      export PATH=${TRAVIS_BUILD_DIR}/glslang/bin:$PATH
+      glslangValidator --version
+    end
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
       cd ..
       export PATH=${TRAVIS_BUILD_DIR}/glslang/bin:$PATH
       glslangValidator --version
-    end
+    fi
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,11 @@ before_install:
       export PATH=${TRAVIS_BUILD_DIR}/glslang/bin:$PATH
       glslangValidator --version
     fi
-
 matrix:
   allow_failures:
     - rust: nightly
   fast_finish: true
 script:
-  - chmod +x spirvtest && ./spirvtest
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; chmod +x spirvtest && ./spirvtest; fi
   - cargo test --verbose --features opengl
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cargo test --verbose --features vulkan --release; fi

--- a/spirvtest
+++ b/spirvtest
@@ -1,14 +1,12 @@
 #!/bin/bash
-
 # Script to ensure compiled SPIR-V matches it's source on CI.
 
 shader_dir="src/graphics/backend_wgpu/shader/*"
 
 for file in $shader_dir; do
-
     # Look for files with ".frag" or ".vert" extensions
     if [[ "$file" =~ \.(frag|vert)$ ]]; then
-        
+
         test_file="$file.test"
         existing_file="$file.spv"
 

--- a/spirvtest
+++ b/spirvtest
@@ -13,6 +13,12 @@ for file in $shader_dir; do
         # Compile the file
         res=$(glslangValidator -V110 $file -o $test_file)
 
+        if [[ $? != 0 ]]; then
+            echo "Error: Failed to compile $file"
+            echo $res
+            exit 1
+        fi
+
         # Compare the newly compiled file with the compiled file from the repo.
         cmp=$(cmp $existing_file $test_file)
 

--- a/spirvtest
+++ b/spirvtest
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Script to ensure compiled SPIR-V matches it's source on CI.
+
+shader_dir="src/graphics/backend_wgpu/shader/*"
+
+for file in $shader_dir; do
+
+    # Look for files with ".frag" or ".vert" extensions
+    if [[ "$file" =~ \.(frag|vert)$ ]]; then
+        
+        test_file="$file.test"
+        existing_file="$file.spv"
+
+        # Compile the file
+        res=$(glslangValidator -V110 $file -o $test_file)
+
+        # Compare the newly compiled file with the compiled file from the repo.
+        cmp=$(cmp $existing_file $test_file)
+
+        if [ "$cmp" != "" ] 
+        then
+            echo "Error: The compiled SPIR-V differs from the compiled SPIR-V from the repository."
+            exit 1
+        else
+            echo "Compiled SPIR-V for $file matches $existing_file"
+        fi
+    fi
+done
+
+

--- a/spirvtest
+++ b/spirvtest
@@ -21,6 +21,7 @@ for file in $shader_dir; do
         if [ "$cmp" != "" ] 
         then
             echo "Error: The compiled SPIR-V differs from the compiled SPIR-V from the repository."
+            echo "Error: Compiled SPIR-V for $file differs from $existing_file"
             exit 1
         else
             echo "Compiled SPIR-V for $file matches $existing_file"

--- a/spirvtest
+++ b/spirvtest
@@ -16,13 +16,12 @@ for file in $shader_dir; do
         # Compare the newly compiled file with the compiled file from the repo.
         cmp=$(cmp $existing_file $test_file)
 
-        if [ "$cmp" != "" ] 
-        then
+        if [[ "$cmp" != "" ]]; then
             echo "Error: The compiled SPIR-V differs from the compiled SPIR-V from the repository."
-            echo "Error: Compiled SPIR-V for $file differs from $existing_file"
+            echo "Error: Compiled SPIR-V in $test_file differs from $existing_file"
             exit 1
         else
-            echo "Compiled SPIR-V for $file matches $existing_file"
+            echo "Compiled SPIR-V in $test_file matches $existing_file"
         fi
     fi
 done


### PR DESCRIPTION
Implements and closes #22 

Adds a bash script that is executed on CI to see if the compiled SPIR-V differs from the source shader.

I wanted to test this "locally" before opening a PR but was unable to get Travis to test on my fork, so this is more of a work in progress than I would like.