### PR TITLE
Deny `rust_2018_idioms`

### DIFF
--- a/src/debug/basic.rs
+++ b/src/debug/basic.rs
@@ -188,7 +188,7 @@ impl Debug {
     }
 
     /// Draws the debug information.
-    pub fn draw(&mut self, frame: &mut graphics::Frame) {
+    pub fn draw(&mut self, frame: &mut graphics::Frame<'_>) {
         if self.frames_until_refresh <= 0 {
             self.text.clear();
             self.refresh_text();
@@ -231,7 +231,7 @@ impl Debug {
         }
     }
 
-    fn draw_text(&mut self, frame: &mut graphics::Frame) {
+    fn draw_text(&mut self, frame: &mut graphics::Frame<'_>) {
         for (row, (key, value)) in self.text.iter().enumerate() {
             let y = row as f32 * Self::ROW_HEIGHT;
 
@@ -304,7 +304,7 @@ fn format_duration(duration: &time::Duration) -> String {
 }
 
 impl std::fmt::Debug for Debug {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "Debug {{ load: {:?}, interact: {:?}, update: {:?}, draw: {:?}, frame: {:?} }}",

--- a/src/debug/null.rs
+++ b/src/debug/null.rs
@@ -35,5 +35,5 @@ impl Debug {
     }
 
     #[allow(missing_docs)]
-    pub fn draw(&mut self, _frame: &mut graphics::Frame) {}
+    pub fn draw(&mut self, _frame: &mut graphics::Frame<'_>) {}
 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -76,7 +76,7 @@ pub trait Game {
     /// [`Game`]: trait.Game.html
     /// [`graphics`]: graphics/index.html
     /// [`update`]: #method.update
-    fn draw(&mut self, frame: &mut Frame, timer: &Timer);
+    fn draw(&mut self, frame: &mut Frame<'_>, timer: &Timer);
 
     /// Consumes [`Input`] to let users interact with the [`Game`].
     ///
@@ -138,7 +138,7 @@ pub trait Game {
     fn debug(
         &self,
         _input: &Self::Input,
-        frame: &mut Frame,
+        frame: &mut Frame<'_>,
         debug: &mut Debug,
     ) {
         debug.draw(frame);

--- a/src/graphics/backend_gfx/font.rs
+++ b/src/graphics/backend_gfx/font.rs
@@ -18,13 +18,13 @@ impl Font {
         }
     }
 
-    pub fn add(&mut self, text: Text) {
-        let section: gfx_glyph::Section = text.into();
+    pub fn add(&mut self, text: Text<'_>) {
+        let section: gfx_glyph::Section<'_> = text.into();
         self.glyphs.queue(section);
     }
 
-    pub fn measure(&mut self, text: Text) -> (f32, f32) {
-        let section: gfx_glyph::Section = text.into();
+    pub fn measure(&mut self, text: Text<'_>) -> (f32, f32) {
+        let section: gfx_glyph::Section<'_> = text.into();
         let bounds = self.glyphs.pixel_bounds(section);
 
         match bounds {

--- a/src/graphics/backend_gfx/pipeline.rs
+++ b/src/graphics/backend_gfx/pipeline.rs
@@ -179,7 +179,7 @@ pub struct Shader {
 }
 
 impl Shader {
-    pub fn new(factory: &mut gl::Factory, init: pipe::Init) -> Shader {
+    pub fn new(factory: &mut gl::Factory, init: pipe::Init<'_>) -> Shader {
         let set = factory
             .create_shader_set(
                 include_bytes!("shader/basic.vert"),

--- a/src/graphics/backend_wgpu/font.rs
+++ b/src/graphics/backend_wgpu/font.rs
@@ -18,13 +18,13 @@ impl Font {
         }
     }
 
-    pub fn add(&mut self, text: Text) {
-        let section: wgpu_glyph::Section = text.into();
+    pub fn add(&mut self, text: Text<'_>) {
+        let section: wgpu_glyph::Section<'_> = text.into();
         self.glyphs.queue(section);
     }
 
-    pub fn measure(&mut self, text: Text) -> (f32, f32) {
-        let section: wgpu_glyph::Section = text.into();
+    pub fn measure(&mut self, text: Text<'_>) -> (f32, f32) {
+        let section: wgpu_glyph::Section<'_> = text.into();
         let bounds = self.glyphs.pixel_bounds(section);
 
         match bounds {

--- a/src/graphics/backend_wgpu/texture.rs
+++ b/src/graphics/backend_wgpu/texture.rs
@@ -16,7 +16,7 @@ pub struct Texture {
 }
 
 impl fmt::Debug for Texture {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "Texture {{ width: {}, height: {}, layers: {} }}",

--- a/src/graphics/batch.rs
+++ b/src/graphics/batch.rs
@@ -45,7 +45,7 @@ impl Batch {
     /// Draw the [`Batch`] at the given position.
     ///
     /// [`Batch`]: struct.Batch.html
-    pub fn draw(&self, position: Point, target: &mut Target) {
+    pub fn draw(&self, position: Point, target: &mut Target<'_>) {
         let mut translated = target.transform(Transformation::translate(
             Vector::new(position.x, position.y),
         ));
@@ -65,7 +65,7 @@ impl Batch {
 }
 
 impl std::fmt::Debug for Batch {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Batch {{ image: {:?} }}", self.image,)
     }
 }

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -1,5 +1,5 @@
 use crate::graphics::gpu::{self, texture, Gpu};
-use crate::graphics::{Target, IntoQuad};
+use crate::graphics::{IntoQuad, Target};
 use crate::load::Task;
 use crate::Result;
 
@@ -65,19 +65,19 @@ impl Canvas {
     ///
     /// [`Canvas`]: struct.Canvas.html
     /// [`Target`]: struct.Target.html
-    pub fn draw<Q: IntoQuad>(&self, quad: Q, target: &mut Target) {
+    pub fn draw<Q: IntoQuad>(&self, quad: Q, target: &mut Target<'_>) {
         target.draw_texture_quads(
             &self.drawable.texture(),
             &[gpu::Instance::from(quad.into_quad(
                 1.0 / self.width() as f32,
-                1.0 / self.height() as f32
+                1.0 / self.height() as f32,
             ))],
         );
     }
 }
 
 impl std::fmt::Debug for Canvas {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "Canvas {{ width: {}, height: {} }}",

--- a/src/graphics/font.rs
+++ b/src/graphics/font.rs
@@ -22,14 +22,14 @@ impl Font {
     }
 
     /// Adds text to this font.
-    pub fn add(&mut self, text: Text) {
+    pub fn add(&mut self, text: Text<'_>) {
         self.0.add(text)
     }
 
     /// Computes the pixel bounds of the given [`Text`].
     ///
     /// [`Text`]: struct.Text.html
-    pub fn measure(&mut self, text: Text) -> (f32, f32) {
+    pub fn measure(&mut self, text: Text<'_>) -> (f32, f32) {
         self.0.measure(text)
     }
 
@@ -37,7 +37,7 @@ impl Font {
     ///
     /// [`Font`]: struct.Font.html
     #[inline]
-    pub fn draw(&mut self, target: &mut Target) {
+    pub fn draw(&mut self, target: &mut Target<'_>) {
         target.draw_font(&mut self.0)
     }
 }

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -100,7 +100,7 @@ impl Image {
     ///
     /// [`Image`]: struct.Image.html
     #[inline]
-    pub fn draw<Q: IntoQuad>(&self, quad: Q, target: &mut Target) {
+    pub fn draw<Q: IntoQuad>(&self, quad: Q, target: &mut Target<'_>) {
         target.draw_texture_quads(
             &self.texture,
             &[gpu::Instance::from(quad.into_quad(
@@ -112,7 +112,7 @@ impl Image {
 }
 
 impl std::fmt::Debug for Image {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "Image {{ width: {}, height: {} }}",

--- a/src/graphics/target.rs
+++ b/src/graphics/target.rs
@@ -22,7 +22,7 @@ impl<'a> Target<'a> {
         view: TargetView,
         width: f32,
         height: f32,
-    ) -> Target {
+    ) -> Target<'_> {
         Target {
             gpu,
             view,
@@ -36,7 +36,7 @@ impl<'a> Target<'a> {
         width: f32,
         height: f32,
         transformation: Transformation,
-    ) -> Target {
+    ) -> Target<'_> {
         let mut target = Self::new(gpu, view, width, height);
         target.transformation = transformation * target.transformation;
         target
@@ -76,7 +76,7 @@ impl<'a> Target<'a> {
     /// ```
     ///
     /// [`Target`]: struct.Target.html
-    pub fn transform(&mut self, transformation: Transformation) -> Target {
+    pub fn transform(&mut self, transformation: Transformation) -> Target<'_> {
         Target {
             gpu: self.gpu,
             view: self.view.clone(),
@@ -111,7 +111,7 @@ impl<'a> Target<'a> {
 }
 
 impl<'a> std::fmt::Debug for Target<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Target {{ transformation: {:?} }}", self.transformation)
     }
 }

--- a/src/graphics/texture_array.rs
+++ b/src/graphics/texture_array.rs
@@ -66,7 +66,7 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::KeyNotFound(key) => write!(f, "Key not found: {}", key),
             Error::ImageIsTooBig(path) => {

--- a/src/graphics/texture_array/batch.rs
+++ b/src/graphics/texture_array/batch.rs
@@ -46,7 +46,7 @@ impl Batch {
     /// Draw the [`Batch`] at the given position.
     ///
     /// [`Batch`]: struct.Batch.html
-    pub fn draw(&self, position: Point, target: &mut Target) {
+    pub fn draw(&self, position: Point, target: &mut Target<'_>) {
         let mut translated = target.transform(Transformation::translate(
             Vector::new(position.x, position.y),
         ));

--- a/src/graphics/window/frame.rs
+++ b/src/graphics/window/frame.rs
@@ -19,7 +19,7 @@ pub struct Frame<'a> {
 }
 
 impl<'a> Frame<'a> {
-    pub(crate) fn new(window: &mut Window) -> Frame {
+    pub(crate) fn new(window: &mut Window) -> Frame<'_> {
         Frame { window }
     }
 
@@ -47,7 +47,7 @@ impl<'a> Frame<'a> {
     /// You will need to use this in order to render some resources to it.
     ///
     /// [`Target`]: struct.Target.html
-    pub fn as_target(&mut self) -> Target {
+    pub fn as_target(&mut self) -> Target<'_> {
         let view = self.window.surface.target().clone();
         let width = self.window.width;
         let height = self.window.height;

--- a/src/graphics/window/mod.rs
+++ b/src/graphics/window/mod.rs
@@ -80,7 +80,7 @@ impl Window {
     ///
     /// [`Frame`]: struct.Frame.html
     /// [`Window`]: struct.Window.html
-    pub(crate) fn frame(&mut self) -> Frame {
+    pub(crate) fn frame(&mut self) -> Frame<'_> {
         Frame::new(self)
     }
 
@@ -139,7 +139,7 @@ impl Window {
 }
 
 impl std::fmt::Debug for Window {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "Window {{ width: {}, height: {} }}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@
 #![deny(missing_debug_implementations)]
 #![deny(unused_results)]
 #![deny(unsafe_code)]
+#![deny(rust_2018_idioms)]
 
 mod debug;
 mod game;

--- a/src/load.rs
+++ b/src/load.rs
@@ -94,7 +94,7 @@ use crate::Result;
 /// [`map`]: #method.map
 pub struct Task<T> {
     total_work: u32,
-    function: Box<Fn(&mut Worker) -> Result<T>>,
+    function: Box<dyn Fn(&mut Worker<'_>) -> Result<T>>,
 }
 
 impl<T> Task<T> {
@@ -162,7 +162,7 @@ impl<T> Task<T> {
 
     pub(crate) fn sequence<F>(total_work: u32, f: F) -> Task<T>
     where
-        F: 'static + Fn(&mut Worker) -> Result<T>,
+        F: 'static + Fn(&mut Worker<'_>) -> Result<T>,
     {
         Task {
             total_work,
@@ -280,14 +280,14 @@ impl<T> Task<T> {
 }
 
 impl<T> std::fmt::Debug for Task<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Task {{ total_work: {} }}", self.total_work)
     }
 }
 
 pub(crate) struct Worker<'a> {
     window: &'a mut graphics::Window,
-    listener: &'a mut FnMut(&Progress, &mut graphics::Window) -> (),
+    listener: &'a mut dyn FnMut(&Progress, &mut graphics::Window) -> (),
     progress: Progress,
 }
 
@@ -305,7 +305,7 @@ impl<'a> Worker<'a> {
     pub fn with_stage<T>(
         &mut self,
         title: String,
-        f: &Box<Fn(&mut Worker) -> T>,
+        f: &Box<dyn Fn(&mut Worker<'_>) -> T>,
     ) -> T {
         self.progress.stages.push(title);
         self.notify_progress(0);

--- a/src/load/loading_screen.rs
+++ b/src/load/loading_screen.rs
@@ -61,7 +61,7 @@ pub trait LoadingScreen {
     /// [`Progress`]: ../struct.Progress.html
     /// [`Frame`]: ../../graphics/struct.Frame.html
     /// [`Game::draw`]: ../../trait.Game.html#tymethod.draw
-    fn draw(&mut self, progress: &Progress, frame: &mut graphics::Frame);
+    fn draw(&mut self, progress: &Progress, frame: &mut graphics::Frame<'_>);
 
     /// Runs the [`LoadingScreen`] with a task and obtain its result.
     ///
@@ -86,5 +86,6 @@ impl LoadingScreen for () {
         Ok(())
     }
 
-    fn draw(&mut self, _progress: &Progress, _frame: &mut graphics::Frame) {}
+    fn draw(&mut self, _progress: &Progress, _frame: &mut graphics::Frame<'_>) {
+    }
 }

--- a/src/load/loading_screen/progress_bar.rs
+++ b/src/load/loading_screen/progress_bar.rs
@@ -31,7 +31,7 @@ impl LoadingScreen for ProgressBar {
         })
     }
 
-    fn draw(&mut self, progress: &Progress, frame: &mut graphics::Frame) {
+    fn draw(&mut self, progress: &Progress, frame: &mut graphics::Frame<'_>) {
         frame.clear(graphics::Color::BLACK);
 
         self.pencil.draw(

--- a/src/result.rs
+++ b/src/result.rs
@@ -29,7 +29,7 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::WindowCreation(error) => {
                 write!(f, "Window creation error: {}", error)

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -243,7 +243,7 @@ pub trait UserInterface: Game {
     fn layout(
         &mut self,
         window: &Window,
-    ) -> self::core::Element<Self::Message, Self::Renderer>;
+    ) -> self::core::Element<'_, Self::Message, Self::Renderer>;
 
     /// Builds the renderer configuration for the user interface.
     ///

--- a/src/ui/core/element.rs
+++ b/src/ui/core/element.rs
@@ -11,11 +11,11 @@ use crate::ui::core::{Event, Hasher, Layout, MouseCursor, Node, Widget};
 /// [`Widget`]: trait.Widget.html
 /// [`Element`]: struct.Element.html
 pub struct Element<'a, Message, Renderer> {
-    pub(crate) widget: Box<Widget<Message, Renderer> + 'a>,
+    pub(crate) widget: Box<dyn Widget<Message, Renderer> + 'a>,
 }
 
 impl<'a, Message, Renderer> std::fmt::Debug for Element<'a, Message, Renderer> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Element")
             .field("widget", &self.widget)
             .finish()
@@ -156,19 +156,19 @@ impl<'a, Message, Renderer> Element<'a, Message, Renderer> {
 }
 
 pub struct Map<'a, A, B, Renderer> {
-    widget: Box<Widget<A, Renderer> + 'a>,
-    mapper: Box<Fn(A) -> B>,
+    widget: Box<dyn Widget<A, Renderer> + 'a>,
+    mapper: Box<dyn Fn(A) -> B>,
 }
 
 impl<'a, A, B, Renderer> std::fmt::Debug for Map<'a, A, B, Renderer> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Map").field("widget", &self.widget).finish()
     }
 }
 
 impl<'a, A, B, Renderer> Map<'a, A, B, Renderer> {
     pub fn new<F>(
-        widget: Box<Widget<A, Renderer> + 'a>,
+        widget: Box<dyn Widget<A, Renderer> + 'a>,
         mapper: F,
     ) -> Map<'a, A, B, Renderer>
     where
@@ -192,7 +192,7 @@ where
     fn on_event(
         &mut self,
         event: Event,
-        layout: Layout,
+        layout: Layout<'_>,
         cursor_position: Point,
         messages: &mut Vec<B>,
     ) {
@@ -214,7 +214,7 @@ where
     fn draw(
         &self,
         renderer: &mut Renderer,
-        layout: Layout,
+        layout: Layout<'_>,
         cursor_position: Point,
     ) -> MouseCursor {
         self.widget.draw(renderer, layout, cursor_position)

--- a/src/ui/core/interface.rs
+++ b/src/ui/core/interface.rs
@@ -70,7 +70,7 @@ where
     pub fn draw(
         &self,
         renderer: &mut Renderer,
-        frame: &mut Frame,
+        frame: &mut Frame<'_>,
         cursor_position: Point,
     ) -> MouseCursor {
         let Interface { root, layout, .. } = self;
@@ -91,7 +91,7 @@ where
         }
     }
 
-    fn layout(layout: &result::Layout) -> Layout {
+    fn layout(layout: &result::Layout) -> Layout<'_> {
         Layout::new(layout, Point::new(0.0, 0.0))
     }
 }

--- a/src/ui/core/renderer.rs
+++ b/src/ui/core/renderer.rs
@@ -35,5 +35,5 @@ pub trait Renderer {
     /// [`Renderer`]: trait.Renderer.html
     /// [`Batch`]: ../../graphics/struct.Batch.html
     /// [`Batch::draw`]: ../../graphics/struct.Batch.html#method.draw
-    fn flush(&mut self, frame: &mut Frame);
+    fn flush(&mut self, frame: &mut Frame<'_>);
 }

--- a/src/ui/core/widget.rs
+++ b/src/ui/core/widget.rs
@@ -30,7 +30,7 @@ pub trait Widget<Message, Renderer>: std::fmt::Debug {
     fn draw(
         &self,
         renderer: &mut Renderer,
-        layout: Layout,
+        layout: Layout<'_>,
         cursor_position: Point,
     ) -> MouseCursor;
 
@@ -66,7 +66,7 @@ pub trait Widget<Message, Renderer>: std::fmt::Debug {
     fn on_event(
         &mut self,
         _event: Event,
-        _layout: Layout,
+        _layout: Layout<'_>,
         _cursor_position: Point,
         _messages: &mut Vec<Message>,
     ) {

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -25,7 +25,7 @@ pub struct Renderer {
 }
 
 impl std::fmt::Debug for Renderer {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Renderer")
             .field("sprites", &self.sprites)
             .finish()
@@ -44,7 +44,7 @@ impl core::Renderer for Renderer {
             })
     }
 
-    fn flush(&mut self, frame: &mut Frame) {
+    fn flush(&mut self, frame: &mut Frame<'_>) {
         let target = &mut frame.as_target();
 
         self.sprites.draw(Point::new(0.0, 0.0), target);

--- a/src/ui/widget/button.rs
+++ b/src/ui/widget/button.rs
@@ -51,7 +51,7 @@ impl<'a, Message> std::fmt::Debug for Button<'a, Message>
 where
     Message: std::fmt::Debug,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Button")
             .field("state", &self.state)
             .field("label", &self.label)
@@ -139,7 +139,7 @@ where
     fn on_event(
         &mut self,
         event: Event,
-        layout: Layout,
+        layout: Layout<'_>,
         cursor_position: Point,
         messages: &mut Vec<Message>,
     ) {
@@ -176,7 +176,7 @@ where
     fn draw(
         &self,
         renderer: &mut Renderer,
-        layout: Layout,
+        layout: Layout<'_>,
         cursor_position: Point,
     ) -> MouseCursor {
         renderer.draw(

--- a/src/ui/widget/checkbox.rs
+++ b/src/ui/widget/checkbox.rs
@@ -38,13 +38,13 @@ use crate::ui::widget::{text, Column, Row, Text};
 /// ![Checkbox drawn by the built-in renderer](https://github.com/hecrj/coffee/blob/bda9818f823dfcb8a7ad0ff4940b4d4b387b5208/images/ui/checkbox.png?raw=true)
 pub struct Checkbox<Message> {
     is_checked: bool,
-    on_toggle: Box<Fn(bool) -> Message>,
+    on_toggle: Box<dyn Fn(bool) -> Message>,
     label: String,
     label_color: Color,
 }
 
 impl<Message> std::fmt::Debug for Checkbox<Message> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Checkbox")
             .field("is_checked", &self.is_checked)
             .field("label", &self.label)
@@ -102,7 +102,7 @@ where
     fn on_event(
         &mut self,
         event: Event,
-        layout: Layout,
+        layout: Layout<'_>,
         cursor_position: Point,
         messages: &mut Vec<Message>,
     ) {
@@ -126,14 +126,15 @@ where
     fn draw(
         &self,
         renderer: &mut Renderer,
-        layout: Layout,
+        layout: Layout<'_>,
         cursor_position: Point,
     ) -> MouseCursor {
         let children: Vec<_> = layout.children().collect();
 
         let text_bounds = children[1].bounds();
 
-        (renderer as &mut text::Renderer).draw(
+        text::Renderer::draw(
+            renderer,
             text_bounds,
             &self.label,
             20.0,
@@ -142,7 +143,8 @@ where
             VerticalAlignment::Top,
         );
 
-        (renderer as &mut self::Renderer).draw(
+        self::Renderer::draw(
+            renderer,
             cursor_position,
             children[0].bounds(),
             text_bounds,

--- a/src/ui/widget/column.rs
+++ b/src/ui/widget/column.rs
@@ -18,7 +18,7 @@ pub struct Column<'a, Message, Renderer> {
 }
 
 impl<'a, Message, Renderer> std::fmt::Debug for Column<'a, Message, Renderer> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Column")
             .field("style", &self.style)
             .field("spacing", &self.spacing)
@@ -165,7 +165,7 @@ impl<'a, Message, Renderer> Widget<Message, Renderer>
     fn on_event(
         &mut self,
         event: Event,
-        layout: Layout,
+        layout: Layout<'_>,
         cursor_position: Point,
         messages: &mut Vec<Message>,
     ) {
@@ -181,7 +181,7 @@ impl<'a, Message, Renderer> Widget<Message, Renderer>
     fn draw(
         &self,
         renderer: &mut Renderer,
-        layout: Layout,
+        layout: Layout<'_>,
         cursor_position: Point,
     ) -> MouseCursor {
         let mut cursor = MouseCursor::OutOfBounds;

--- a/src/ui/widget/radio.rs
+++ b/src/ui/widget/radio.rs
@@ -61,7 +61,7 @@ impl<Message> std::fmt::Debug for Radio<Message>
 where
     Message: std::fmt::Debug,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Radio")
             .field("is_selected", &self.is_selected)
             .field("on_click", &self.on_click)
@@ -122,7 +122,7 @@ where
     fn on_event(
         &mut self,
         event: Event,
-        layout: Layout,
+        layout: Layout<'_>,
         cursor_position: Point,
         messages: &mut Vec<Message>,
     ) {
@@ -142,7 +142,7 @@ where
     fn draw(
         &self,
         renderer: &mut Renderer,
-        layout: Layout,
+        layout: Layout<'_>,
         cursor_position: Point,
     ) -> MouseCursor {
         let children: Vec<_> = layout.children().collect();
@@ -150,7 +150,8 @@ where
         let mut text_bounds = children[1].bounds();
         text_bounds.y -= 2.0;
 
-        (renderer as &mut text::Renderer).draw(
+        text::Renderer::draw(
+            renderer,
             text_bounds,
             &self.label,
             20.0,
@@ -159,7 +160,8 @@ where
             VerticalAlignment::Top,
         );
 
-        (renderer as &mut self::Renderer).draw(
+        self::Renderer::draw(
+            renderer,
             cursor_position,
             children[0].bounds(),
             layout.bounds(),

--- a/src/ui/widget/row.rs
+++ b/src/ui/widget/row.rs
@@ -18,7 +18,7 @@ pub struct Row<'a, Message, Renderer> {
 }
 
 impl<'a, Message, Renderer> std::fmt::Debug for Row<'a, Message, Renderer> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Row")
             .field("style", &self.style)
             .field("spacing", &self.spacing)
@@ -162,7 +162,7 @@ impl<'a, Message, Renderer> Widget<Message, Renderer>
     fn on_event(
         &mut self,
         event: Event,
-        layout: Layout,
+        layout: Layout<'_>,
         cursor_position: Point,
         messages: &mut Vec<Message>,
     ) {
@@ -178,7 +178,7 @@ impl<'a, Message, Renderer> Widget<Message, Renderer>
     fn draw(
         &self,
         renderer: &mut Renderer,
-        layout: Layout,
+        layout: Layout<'_>,
         cursor_position: Point,
     ) -> MouseCursor {
         let mut cursor = MouseCursor::OutOfBounds;

--- a/src/ui/widget/slider.rs
+++ b/src/ui/widget/slider.rs
@@ -50,7 +50,7 @@ pub struct Slider<'a, Message> {
 }
 
 impl<'a, Message> std::fmt::Debug for Slider<'a, Message> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Slider")
             .field("state", &self.state)
             .field("range", &self.range)
@@ -111,7 +111,7 @@ where
     fn on_event(
         &mut self,
         event: Event,
-        layout: Layout,
+        layout: Layout<'_>,
         cursor_position: Point,
         messages: &mut Vec<Message>,
     ) {
@@ -158,7 +158,7 @@ where
     fn draw(
         &self,
         renderer: &mut Renderer,
-        layout: Layout,
+        layout: Layout<'_>,
         cursor_position: Point,
     ) -> MouseCursor {
         renderer.draw(

--- a/src/ui/widget/text.rs
+++ b/src/ui/widget/text.rs
@@ -120,7 +120,7 @@ where
     fn draw(
         &self,
         renderer: &mut Renderer,
-        layout: Layout,
+        layout: Layout<'_>,
         _cursor_position: Point,
     ) -> MouseCursor {
         renderer.draw(


### PR DESCRIPTION
This adds a `#![deny(rust_2018_idioms)]` and fixes all the compiler errors.