### PR TITLE
Fix `Font::measure` and `Text` widget

### DIFF
--- a/src/graphics/backend_gfx/font.rs
+++ b/src/graphics/backend_gfx/font.rs
@@ -25,10 +25,10 @@ impl Font {
 
     pub fn measure(&mut self, text: Text<'_>) -> (f32, f32) {
         let section: gfx_glyph::Section<'_> = text.into();
-        let bounds = self.glyphs.pixel_bounds(section);
+        let bounds = self.glyphs.glyph_bounds(section);
 
         match bounds {
-            Some(bounds) => (bounds.width() as f32, bounds.height() as f32),
+            Some(bounds) => (bounds.width(), bounds.height()),
             None => (0.0, 0.0),
         }
     }

--- a/src/graphics/backend_wgpu/font.rs
+++ b/src/graphics/backend_wgpu/font.rs
@@ -25,10 +25,10 @@ impl Font {
 
     pub fn measure(&mut self, text: Text<'_>) -> (f32, f32) {
         let section: wgpu_glyph::Section<'_> = text.into();
-        let bounds = self.glyphs.pixel_bounds(section);
+        let bounds = self.glyphs.glyph_bounds(section);
 
         match bounds {
-            Some(bounds) => (bounds.width() as f32, bounds.height() as f32),
+            Some(bounds) => (bounds.width(), bounds.height()),
             None => (0.0, 0.0),
         }
     }

--- a/src/graphics/font.rs
+++ b/src/graphics/font.rs
@@ -26,7 +26,7 @@ impl Font {
         self.0.add(text)
     }
 
-    /// Computes the pixel bounds of the given [`Text`].
+    /// Computes the layout bounds of the given [`Text`].
     ///
     /// [`Text`]: struct.Text.html
     pub fn measure(&mut self, text: Text<'_>) -> (f32, f32) {

--- a/src/ui/renderer/text.rs
+++ b/src/ui/renderer/text.rs
@@ -45,10 +45,7 @@ impl text::Renderer for Renderer {
 
                 let (width, height) = font.borrow_mut().measure(text);
 
-                let size = Size {
-                    width: width + (size / 10.0).round(),
-                    height: height + (size / 3.0).round(),
-                };
+                let size = Size { width, height };
 
                 // If the text has no width boundary we avoid caching as the
                 // layout engine may just be measuring text in a row.


### PR DESCRIPTION
Fixes #43.

The fix consists in using the brand new `GlyphBrush::glyph_bounds` method instead of `GlyphBrush::pixel_bounds` (see https://github.com/alexheretic/glyph-brush/issues/68). The `Text` widget measure function can directly return the result now!