### PR TITLE
Implement `Element::explain`

### DIFF
--- a/src/graphics/mesh.rs
+++ b/src/graphics/mesh.rs
@@ -18,6 +18,13 @@ impl Mesh {
         }
     }
 
+    /// Returns true if the [`Mesh`] is empty.
+    ///
+    /// [`Mesh`]: struct.Mesh.html
+    pub fn is_empty(&self) -> bool {
+        self.buffers.vertices.is_empty()
+    }
+
     /// Adds a filled [`Shape`] to the [`Mesh`].
     ///
     /// [`Shape`]: enum.Shape.html

--- a/src/ui/core/renderer.rs
+++ b/src/ui/core/renderer.rs
@@ -1,5 +1,6 @@
-use crate::graphics::Frame;
+use crate::graphics::{Color, Frame};
 use crate::load::Task;
+use crate::ui::core::Layout;
 
 /// The renderer of a user interface.
 ///
@@ -21,6 +22,12 @@ pub trait Renderer {
     fn load(config: Self::Configuration) -> Task<Self>
     where
         Self: Sized;
+
+    /// Explains the [`Layout`] of an [`Element`] for debugging purposes.
+    ///
+    /// This will be called when [`Element::explain`] has been used. It should
+    /// _explain_ the [`Layout`] graphically.
+    fn explain(&mut self, layout: &Layout<'_>, color: Color);
 
     /// Flushes the renderer to draw on the given [`Frame`].
     ///

--- a/src/ui/core/renderer.rs
+++ b/src/ui/core/renderer.rs
@@ -27,6 +27,10 @@ pub trait Renderer {
     ///
     /// This will be called when [`Element::explain`] has been used. It should
     /// _explain_ the [`Layout`] graphically.
+    ///
+    /// [`Layout`]: struct.Layout.html
+    /// [`Element`]: struct.Element.html
+    /// [`Element::explain`]: struct.Element.html#method.explain
     fn explain(&mut self, layout: &Layout<'_>, color: Color);
 
     /// Flushes the renderer to draw on the given [`Frame`].

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -4,7 +4,7 @@ mod radio;
 mod slider;
 mod text;
 
-use crate::graphics::{Batch, Font, Frame, Image, Point};
+use crate::graphics::{Batch, Color, Font, Frame, Image, Mesh, Point, Shape};
 use crate::load::{Join, Task};
 use crate::ui::core;
 
@@ -22,6 +22,7 @@ use std::rc::Rc;
 pub struct Renderer {
     pub(crate) sprites: Batch,
     pub(crate) font: Rc<RefCell<Font>>,
+    explain_mesh: Mesh,
 }
 
 impl std::fmt::Debug for Renderer {
@@ -41,7 +42,17 @@ impl core::Renderer for Renderer {
             .map(|(sprites, font)| Renderer {
                 sprites: Batch::new(sprites),
                 font: Rc::new(RefCell::new(font)),
+                explain_mesh: Mesh::new(),
             })
+    }
+
+    fn explain(&mut self, layout: &core::Layout<'_>, color: Color) {
+        self.explain_mesh
+            .stroke(Shape::Rectangle(layout.bounds()), color, 1);
+
+        layout
+            .children()
+            .for_each(|layout| self.explain(&layout, color));
     }
 
     fn flush(&mut self, frame: &mut Frame<'_>) {
@@ -51,6 +62,11 @@ impl core::Renderer for Renderer {
         self.sprites.clear();
 
         self.font.borrow_mut().draw(target);
+
+        if !self.explain_mesh.is_empty() {
+            self.explain_mesh.draw(target);
+            self.explain_mesh = Mesh::new();
+        }
     }
 }
 


### PR DESCRIPTION
This PR implements `Element::explain`, which marks the `Element` as _to be explained by the renderer_. It is inspired by [`elm-ui`'s `explain` attribute](https://package.elm-lang.org/packages/mdgriffith/elm-ui/latest/Element#explain).

It can be very useful for debugging your UI layout. For example:

![image](https://user-images.githubusercontent.com/518289/59534012-66869480-8eed-11e9-8e3a-6269e1aa0aaa.png)