### PR TITLE
Remove `position` argument from `Batch::draw`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   variants can be found. [#29]
 - `input::KeyCode` has been moved to `input::keyboard::KeyCode`. [#29]
 - `input::MouseButton` has been moved to `input::mouse::Button`. [#29]
+- `Batch::draw` and `texture_array::Batch::draw` do not take a `position`
+  argument anymore. Using `Target::transform` before drawing is preferred. [#53]
 - The performance of the particles example has been improved considerably on all
   platforms. [#37]
 
@@ -86,6 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#35]: https://github.com/hecrj/coffee/pull/35
 [#37]: https://github.com/hecrj/coffee/pull/37
 [#50]: https://github.com/hecrj/coffee/pull/50
+[#53]: https://github.com/hecrj/coffee/pull/53
 [Elm]: https://elm-lang.org
 [The Elm Architecture]: https://guide.elm-lang.org/architecture/
 [`stretch`]: https://github.com/vislyhq/stretch

--- a/examples/particles.rs
+++ b/examples/particles.rs
@@ -156,8 +156,7 @@ impl Game for Particles {
         self.batch.par_extend(sprites);
 
         // Draw particles all at once!
-        self.batch
-            .draw(Point::new(0.0, 0.0), &mut frame.as_target());
+        self.batch.draw(&mut frame.as_target());
     }
 }
 

--- a/src/graphics/batch.rs
+++ b/src/graphics/batch.rs
@@ -1,7 +1,7 @@
 use rayon::prelude::*;
 
 use crate::graphics::gpu;
-use crate::graphics::{Image, IntoQuad, Point, Target, Transformation, Vector};
+use crate::graphics::{Image, IntoQuad, Target};
 
 /// A collection of quads that will be drawn all at once using the same
 /// [`Image`].
@@ -42,15 +42,11 @@ impl Batch {
         self.instances.push(instance);
     }
 
-    /// Draw the [`Batch`] at the given position.
+    /// Draw the [`Batch`].
     ///
     /// [`Batch`]: struct.Batch.html
-    pub fn draw(&self, position: Point, target: &mut Target<'_>) {
-        let mut translated = target.transform(Transformation::translate(
-            Vector::new(position.x, position.y),
-        ));
-
-        translated.draw_texture_quads(&self.image.texture, &self.instances[..]);
+    pub fn draw(&self, target: &mut Target<'_>) {
+        target.draw_texture_quads(&self.image.texture, &self.instances[..]);
     }
 
     /// Clear the [`Batch`] contents.

--- a/src/graphics/texture_array/batch.rs
+++ b/src/graphics/texture_array/batch.rs
@@ -1,5 +1,5 @@
 use super::{Index, TextureArray};
-use crate::graphics::{gpu, IntoQuad, Point, Target, Transformation, Vector};
+use crate::graphics::{gpu, IntoQuad, Target};
 
 /// A collection of quads that can be drawn with a [`TextureArray`] all at once.
 ///
@@ -42,15 +42,11 @@ impl Batch {
         self.instances.push(instance);
     }
 
-    /// Draw the [`Batch`] at the given position.
+    /// Draw the [`Batch`].
     ///
     /// [`Batch`]: struct.Batch.html
-    pub fn draw(&self, position: Point, target: &mut Target<'_>) {
-        let mut translated = target.transform(Transformation::translate(
-            Vector::new(position.x, position.y),
-        ));
-
-        translated.draw_texture_quads(
+    pub fn draw(&self, target: &mut Target<'_>) {
+        target.draw_texture_quads(
             &self.texture_array.texture,
             &self.instances[..],
         );

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -4,7 +4,7 @@ mod radio;
 mod slider;
 mod text;
 
-use crate::graphics::{Batch, Color, Font, Frame, Image, Mesh, Point, Shape};
+use crate::graphics::{Batch, Color, Font, Frame, Image, Mesh, Shape};
 use crate::load::{Join, Task};
 use crate::ui::core;
 
@@ -58,7 +58,7 @@ impl core::Renderer for Renderer {
     fn flush(&mut self, frame: &mut Frame<'_>) {
         let target = &mut frame.as_target();
 
-        self.sprites.draw(Point::new(0.0, 0.0), target);
+        self.sprites.draw(target);
         self.sprites.clear();
 
         self.font.borrow_mut().draw(target);


### PR DESCRIPTION
`Batch::draw` and `texture_array::Batch::draw` do not take a `position` argument anymore. Using `Target::transform` before drawing is preferred.