### PR TITLE
Rename `Font::load` to `Font::load_from_bytes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   variants can be found. [#29]
 - `input::KeyCode` has been moved to `input::keyboard::KeyCode`. [#29]
 - `input::MouseButton` has been moved to `input::mouse::Button`. [#29]
+- `Font::load` has been renamed to `Font::load_from_bytes` for consistency. [#55]
 - The performance of the particles example has been improved considerably on all
   platforms. [#37]
 
@@ -86,6 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#35]: https://github.com/hecrj/coffee/pull/35
 [#37]: https://github.com/hecrj/coffee/pull/37
 [#50]: https://github.com/hecrj/coffee/pull/50
+[#55]: https://github.com/hecrj/coffee/pull/55
 [Elm]: https://elm-lang.org
 [The Elm Architecture]: https://guide.elm-lang.org/architecture/
 [`stretch`]: https://github.com/vislyhq/stretch

--- a/examples/color.rs
+++ b/examples/color.rs
@@ -32,7 +32,7 @@ impl Colors {
             Task::using_gpu(|gpu| {
                 Image::from_colors(gpu, &[Self::PRUSSIAN_BLUE])
             }),
-            Font::load(include_bytes!(
+            Font::load_from_bytes(include_bytes!(
                 "../resources/font/Inconsolata-Regular.ttf"
             )),
         )

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -101,7 +101,7 @@ impl InputExample {
     fn load() -> Task<InputExample> {
         (
             Task::using_gpu(|gpu| Image::from_colors(gpu, &Self::COLORS)),
-            Font::load(include_bytes!(
+            Font::load_from_bytes(include_bytes!(
                 "../resources/font/Inconsolata-Regular.ttf"
             )),
         )

--- a/src/graphics/font.rs
+++ b/src/graphics/font.rs
@@ -11,17 +11,25 @@ impl Font {
     pub(crate) const DEFAULT: &'static [u8] =
         include_bytes!("../../resources/font/Inconsolata-Regular.ttf");
 
-    /// Loads a font from raw data.
+    /// Loads a [`Font`] from raw data.
+    ///
+    /// [`Font`]: struct.Font.html
     pub fn from_bytes(gpu: &mut Gpu, bytes: &'static [u8]) -> Result<Font> {
         Ok(Font(gpu.upload_font(bytes)))
     }
 
-    /// Creates a task that loads a font from raw data.
-    pub fn load(bytes: &'static [u8]) -> Task<Font> {
+    /// Creates a [`Task`] that loads a [`Font`] from raw data.
+    ///
+    /// [`Task`]: ../load/struct.Task.html
+    /// [`Font`]: struct.Font.html
+    pub fn load_from_bytes(bytes: &'static [u8]) -> Task<Font> {
         Task::using_gpu(move |gpu| Font::from_bytes(gpu, bytes))
     }
 
-    /// Adds text to this font.
+    /// Adds [`Text`] to this [`Font`].
+    ///
+    /// [`Text`]: struct.Text.html
+    /// [`Font`]: struct.Font.html
     pub fn add(&mut self, text: Text<'_>) {
         self.0.add(text)
     }

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -119,7 +119,7 @@ impl Default for Configuration {
                     ))?,
                 )
             }),
-            font: Font::load(include_bytes!(
+            font: Font::load_from_bytes(include_bytes!(
                 "../../resources/font/Inconsolata-Regular.ttf"
             )),
         }


### PR DESCRIPTION
`Font::load` has been renamed to `Font::load_from_bytes` for consistency.