### PR TITLE
Fix wayland surface resizing

### DIFF
--- a/src/graphics/backend_gfx/surface.rs
+++ b/src/graphics/backend_gfx/surface.rs
@@ -39,15 +39,13 @@ impl Surface {
         self.context.window()
     }
 
-    pub fn resize(&self, size: winit::dpi::PhysicalSize) {
-        self.context.resize(size)
-    }
-
     pub fn target(&self) -> &TargetView {
         &self.target
     }
 
-    pub fn update_viewport(&mut self, _gpu: &mut Gpu) {
+    pub fn resize(&mut self, _gpu: &mut Gpu, size: winit::dpi::PhysicalSize) {
+        self.context.resize(size);
+
         let dimensions = self.target.get_dimensions();
 
         if let Some((target, _depth)) = gfx_window_glutin::update_views_raw(

--- a/src/graphics/backend_gfx/surface.rs
+++ b/src/graphics/backend_gfx/surface.rs
@@ -39,6 +39,10 @@ impl Surface {
         self.context.window()
     }
 
+    pub fn resize(&self, size: winit::dpi::PhysicalSize) {
+        self.context.resize(size)
+    }
+
     pub fn target(&self) -> &TargetView {
         &self.target
     }

--- a/src/graphics/backend_wgpu/surface.rs
+++ b/src/graphics/backend_wgpu/surface.rs
@@ -37,6 +37,9 @@ impl Surface {
         &self.window
     }
 
+    // Only needed for backend_gfx
+    pub fn resize(&self, size: winit::dpi::PhysicalSize) {}
+
     pub fn target(&self) -> &TargetView {
         &self.target
     }

--- a/src/graphics/backend_wgpu/surface.rs
+++ b/src/graphics/backend_wgpu/surface.rs
@@ -20,8 +20,18 @@ impl Surface {
     ) -> Surface {
         let surface = instance.create_surface(&window);
 
+        let size = window
+            .get_inner_size()
+            // TODO: Find out when and why the "inner size" might not be available
+            // and do something smarter here.
+            .unwrap_or(winit::dpi::LogicalSize {
+                width: 1280.0,
+                height: 1024.0,
+            })
+            .to_physical(window.get_hidpi_factor());
+
         let (swap_chain, extent, buffer, target) =
-            new_swap_chain(device, &surface, &window);
+            new_swap_chain(device, &surface, size);
 
         Surface {
             window,
@@ -37,16 +47,13 @@ impl Surface {
         &self.window
     }
 
-    // Only needed for backend_gfx
-    pub fn resize(&self, size: winit::dpi::PhysicalSize) {}
-
     pub fn target(&self) -> &TargetView {
         &self.target
     }
 
-    pub fn update_viewport(&mut self, gpu: &mut Gpu) {
+    pub fn resize(&mut self, gpu: &mut Gpu, size: winit::dpi::PhysicalSize) {
         let (swap_chain, extent, buffer, target) =
-            new_swap_chain(&gpu.device, &self.surface, &self.window);
+            new_swap_chain(&gpu.device, &self.surface, size);
 
         self.swap_chain = swap_chain;
         self.extent = extent;
@@ -96,18 +103,8 @@ impl Surface {
 fn new_swap_chain(
     device: &wgpu::Device,
     surface: &wgpu::Surface,
-    window: &winit::Window,
+    size: winit::dpi::PhysicalSize,
 ) -> (wgpu::SwapChain, wgpu::Extent3d, wgpu::Texture, TargetView) {
-    let size = window
-        .get_inner_size()
-        // TODO: Find out when and why the "inner size" might not be available
-        // and do something smarter here.
-        .unwrap_or(winit::dpi::LogicalSize {
-            width: 1280.0,
-            height: 1024.0,
-        })
-        .to_physical(window.get_hidpi_factor());
-
     let swap_chain = device.create_swap_chain(
         surface,
         &wgpu::SwapChainDescriptor {

--- a/src/graphics/window.rs
+++ b/src/graphics/window.rs
@@ -125,6 +125,8 @@ impl Window {
         let dpi = self.surface.window().get_hidpi_factor();
         let physical_size = new_size.to_physical(dpi);
 
+        self.surface.resize(physical_size);
+
         self.width = physical_size.width as f32;
         self.height = physical_size.height as f32;
     }

--- a/src/graphics/window.rs
+++ b/src/graphics/window.rs
@@ -120,12 +120,10 @@ impl Window {
     }
 
     pub(crate) fn resize(&mut self, new_size: winit::dpi::LogicalSize) {
-        self.surface.update_viewport(&mut self.gpu);
-
         let dpi = self.surface.window().get_hidpi_factor();
         let physical_size = new_size.to_physical(dpi);
 
-        self.surface.resize(physical_size);
+        self.surface.resize(&mut self.gpu, physical_size);
 
         self.width = physical_size.width as f32;
         self.height = physical_size.height as f32;


### PR DESCRIPTION
The surface resize method must be called when resizing in order for resizing to work properly on particular platforms such as wayland. 