### PR TITLE
Update `wgpu` backend to latest API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ gfx_glyph = { version = "0.15", optional = true }
 gfx_winit = { package = "winit", version = "0.19", optional = true }
 
 # wgpu (Vulkan, Metal, D3D)
-wgpu = { version = "0.2", optional = true, git = "https://github.com/gfx-rs/wgpu-rs", rev = "a4ad7ae6ff2fc42396b802968dcc95bbf0612235" }
+wgpu = { version = "0.2", optional = true, git = "https://github.com/gfx-rs/wgpu-rs", rev = "5522c912f7e2f4f33a1167fb0c8ee4549f066dcf" }
 wgpu_glyph = { version = "0.3", optional = true, git = "https://github.com/hecrj/wgpu_glyph" }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,8 @@ gfx_glyph = { version = "0.15", optional = true }
 gfx_winit = { package = "winit", version = "0.19", optional = true }
 
 # wgpu (Vulkan, Metal, D3D)
-wgpu = { version = "0.2", optional = true }
-wgpu_glyph = { version = "0.3", optional = true }
+wgpu = { version = "0.2", optional = true, git = "https://github.com/gfx-rs/wgpu-rs", rev = "a4ad7ae6ff2fc42396b802968dcc95bbf0612235" }
+wgpu_glyph = { version = "0.3", optional = true, git = "https://github.com/hecrj/wgpu_glyph" }
 
 [dev-dependencies]
 # Example dependencies

--- a/src/graphics/backend_wgpu/font.rs
+++ b/src/graphics/backend_wgpu/font.rs
@@ -6,7 +6,7 @@ use crate::graphics::{
 use wgpu_glyph::GlyphCruncher;
 
 pub struct Font {
-    glyphs: wgpu_glyph::GlyphBrush<'static>,
+    glyphs: wgpu_glyph::GlyphBrush<'static, ()>,
 }
 
 impl Font {
@@ -42,10 +42,10 @@ impl Font {
     ) {
         self.glyphs
             .draw_queued_with_transform(
-                transformation.into(),
                 device,
                 encoder,
                 target,
+                transformation.into(),
             )
             .expect("Draw font");
     }

--- a/src/graphics/backend_wgpu/mod.rs
+++ b/src/graphics/backend_wgpu/mod.rs
@@ -35,10 +35,11 @@ impl Gpu {
             power_preference: wgpu::PowerPreference::HighPerformance,
         });
 
-        let mut device = adapter.create_device(&wgpu::DeviceDescriptor {
+        let mut device = adapter.request_device(&wgpu::DeviceDescriptor {
             extensions: wgpu::Extensions {
                 anisotropic_filtering: false,
             },
+            limits: wgpu::Limits::default(),
         });
 
         let quad_pipeline = quad::Pipeline::new(&mut device);
@@ -71,6 +72,7 @@ impl Gpu {
         let _ = self.encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                 attachment: &view,
+                resolve_target: None,
                 load_op: wgpu::LoadOp::Clear,
                 store_op: wgpu::StoreOp::Store,
                 clear_color: wgpu::Color { r, g, b, a },

--- a/src/graphics/backend_wgpu/quad.rs
+++ b/src/graphics/backend_wgpu/quad.rs
@@ -15,17 +15,15 @@ pub struct Pipeline {
 impl Pipeline {
     pub fn new(device: &mut wgpu::Device) -> Pipeline {
         let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-            r_address_mode: wgpu::AddressMode::ClampToEdge,
-            s_address_mode: wgpu::AddressMode::ClampToEdge,
-            t_address_mode: wgpu::AddressMode::ClampToEdge,
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
             mag_filter: wgpu::FilterMode::Nearest,
             min_filter: wgpu::FilterMode::Nearest,
             mipmap_filter: wgpu::FilterMode::Nearest,
             lod_min_clamp: -100.0,
             lod_max_clamp: 100.0,
-            max_anisotropy: 0,
             compare_function: wgpu::CompareFunction::Always,
-            border_color: wgpu::BorderColor::TransparentBlack,
         });
 
         let constant_layout =
@@ -33,12 +31,12 @@ impl Pipeline {
                 bindings: &[
                     wgpu::BindGroupLayoutBinding {
                         binding: 0,
-                        visibility: wgpu::ShaderStageFlags::VERTEX,
+                        visibility: wgpu::ShaderStage::VERTEX,
                         ty: wgpu::BindingType::UniformBuffer,
                     },
                     wgpu::BindGroupLayoutBinding {
                         binding: 1,
-                        visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                        visibility: wgpu::ShaderStage::FRAGMENT,
                         ty: wgpu::BindingType::Sampler,
                     },
                 ],
@@ -49,8 +47,7 @@ impl Pipeline {
         let transform_buffer = device
             .create_buffer_mapped(
                 16,
-                wgpu::BufferUsageFlags::UNIFORM
-                    | wgpu::BufferUsageFlags::TRANSFER_DST,
+                wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::TRANSFER_DST,
             )
             .fill_from_slice(&matrix[..]);
 
@@ -76,7 +73,7 @@ impl Pipeline {
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                 bindings: &[wgpu::BindGroupLayoutBinding {
                     binding: 0,
-                    visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                    visibility: wgpu::ShaderStage::FRAGMENT,
                     ty: wgpu::BindingType::SampledTexture,
                 }],
             });
@@ -98,10 +95,10 @@ impl Pipeline {
                     module: &vs_module,
                     entry_point: "main",
                 },
-                fragment_stage: wgpu::PipelineStageDescriptor {
+                fragment_stage: Some(wgpu::PipelineStageDescriptor {
                     module: &fs_module,
                     entry_point: "main",
-                },
+                }),
                 rasterization_state: wgpu::RasterizationStateDescriptor {
                     front_face: wgpu::FrontFace::Cw,
                     cull_mode: wgpu::CullMode::Back,
@@ -112,51 +109,51 @@ impl Pipeline {
                 primitive_topology: wgpu::PrimitiveTopology::TriangleList,
                 color_states: &[wgpu::ColorStateDescriptor {
                     format: wgpu::TextureFormat::Bgra8UnormSrgb,
-                    color: wgpu::BlendDescriptor {
+                    color_blend: wgpu::BlendDescriptor {
                         src_factor: wgpu::BlendFactor::SrcAlpha,
                         dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
                         operation: wgpu::BlendOperation::Add,
                     },
-                    alpha: wgpu::BlendDescriptor {
+                    alpha_blend: wgpu::BlendDescriptor {
                         src_factor: wgpu::BlendFactor::One,
                         dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
                         operation: wgpu::BlendOperation::Add,
                     },
-                    write_mask: wgpu::ColorWriteFlags::ALL,
+                    write_mask: wgpu::ColorWrite::ALL,
                 }],
                 depth_stencil_state: None,
                 index_format: wgpu::IndexFormat::Uint16,
                 vertex_buffers: &[
                     wgpu::VertexBufferDescriptor {
-                        stride: mem::size_of::<Vertex>() as u32,
+                        stride: mem::size_of::<Vertex>() as u64,
                         step_mode: wgpu::InputStepMode::Vertex,
                         attributes: &[wgpu::VertexAttributeDescriptor {
-                            attribute_index: 0,
+                            shader_location: 0,
                             format: wgpu::VertexFormat::Float2,
                             offset: 0,
                         }],
                     },
                     wgpu::VertexBufferDescriptor {
-                        stride: mem::size_of::<Quad>() as u32,
+                        stride: mem::size_of::<Quad>() as u64,
                         step_mode: wgpu::InputStepMode::Instance,
                         attributes: &[
                             wgpu::VertexAttributeDescriptor {
-                                attribute_index: 1,
+                                shader_location: 1,
                                 format: wgpu::VertexFormat::Float4,
                                 offset: 0,
                             },
                             wgpu::VertexAttributeDescriptor {
-                                attribute_index: 2,
+                                shader_location: 2,
                                 format: wgpu::VertexFormat::Float2,
                                 offset: 4 * 4,
                             },
                             wgpu::VertexAttributeDescriptor {
-                                attribute_index: 3,
+                                shader_location: 3,
                                 format: wgpu::VertexFormat::Float2,
                                 offset: 4 * (4 + 2),
                             },
                             wgpu::VertexAttributeDescriptor {
-                                attribute_index: 4,
+                                shader_location: 4,
                                 format: wgpu::VertexFormat::Uint,
                                 offset: 4 * (4 + 2 + 2),
                             },
@@ -167,23 +164,16 @@ impl Pipeline {
             });
 
         let vertices = device
-            .create_buffer_mapped(
-                QUAD_VERTS.len(),
-                wgpu::BufferUsageFlags::VERTEX,
-            )
+            .create_buffer_mapped(QUAD_VERTS.len(), wgpu::BufferUsage::VERTEX)
             .fill_from_slice(&QUAD_VERTS);
 
         let indices = device
-            .create_buffer_mapped(
-                QUAD_INDICES.len(),
-                wgpu::BufferUsageFlags::INDEX,
-            )
+            .create_buffer_mapped(QUAD_INDICES.len(), wgpu::BufferUsage::INDEX)
             .fill_from_slice(&QUAD_INDICES);
 
         let instances = device.create_buffer(&wgpu::BufferDescriptor {
-            size: mem::size_of::<Quad>() as u32 * Quad::MAX as u32,
-            usage: wgpu::BufferUsageFlags::VERTEX
-                | wgpu::BufferUsageFlags::TRANSFER_DST,
+            size: mem::size_of::<Quad>() as u64 * Quad::MAX as u64,
+            usage: wgpu::BufferUsage::VERTEX | wgpu::BufferUsage::TRANSFER_DST,
         });
 
         Pipeline {
@@ -225,7 +215,7 @@ impl Pipeline {
         let matrix: [f32; 16] = transformation.clone().into();
 
         let transform_buffer = device
-            .create_buffer_mapped(16, wgpu::BufferUsageFlags::TRANSFER_SRC)
+            .create_buffer_mapped(16, wgpu::BufferUsage::TRANSFER_SRC)
             .fill_from_slice(&matrix[..]);
 
         encoder.copy_buffer_to_buffer(
@@ -244,10 +234,7 @@ impl Pipeline {
             let amount = end - i;
 
             let instance_buffer = device
-                .create_buffer_mapped(
-                    amount,
-                    wgpu::BufferUsageFlags::TRANSFER_SRC,
-                )
+                .create_buffer_mapped(amount, wgpu::BufferUsage::TRANSFER_SRC)
                 .fill_from_slice(&instances[i..end]);
 
             encoder.copy_buffer_to_buffer(
@@ -255,7 +242,7 @@ impl Pipeline {
                 0,
                 &self.instances,
                 0,
-                (mem::size_of::<Quad>() * amount) as u32,
+                (mem::size_of::<Quad>() * amount) as u64,
             );
             {
                 let mut render_pass =
@@ -263,6 +250,7 @@ impl Pipeline {
                         color_attachments: &[
                             wgpu::RenderPassColorAttachmentDescriptor {
                                 attachment: target,
+                                resolve_target: None,
                                 load_op: wgpu::LoadOp::Load,
                                 store_op: wgpu::StoreOp::Store,
                                 clear_color: wgpu::Color {
@@ -277,8 +265,8 @@ impl Pipeline {
                     });
 
                 render_pass.set_pipeline(&self.pipeline);
-                render_pass.set_bind_group(0, &self.constants);
-                render_pass.set_bind_group(1, &texture.0);
+                render_pass.set_bind_group(0, &self.constants, &[]);
+                render_pass.set_bind_group(1, &texture.0, &[]);
                 render_pass.set_index_buffer(&self.indices, 0);
                 render_pass.set_vertex_buffers(&[
                     (&self.vertices, 0),

--- a/src/graphics/backend_wgpu/surface.rs
+++ b/src/graphics/backend_wgpu/surface.rs
@@ -75,8 +75,8 @@ impl Surface {
         encoder.copy_texture_to_texture(
             wgpu::TextureCopyView {
                 texture: &self.buffer,
-                level: 0,
-                slice: 0,
+                array_layer: 0,
+                mip_level: 0,
                 origin: wgpu::Origin3d {
                     x: 0.0,
                     y: 0.0,
@@ -85,8 +85,8 @@ impl Surface {
             },
             wgpu::TextureCopyView {
                 texture: &output.texture,
-                level: 0,
-                slice: 0,
+                array_layer: 0,
+                mip_level: 0,
                 origin: wgpu::Origin3d {
                     x: 0.0,
                     y: 0.0,
@@ -108,8 +108,8 @@ fn new_swap_chain(
     let swap_chain = device.create_swap_chain(
         surface,
         &wgpu::SwapChainDescriptor {
-            usage: wgpu::TextureUsageFlags::OUTPUT_ATTACHMENT
-                | wgpu::TextureUsageFlags::TRANSFER_DST,
+            usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT
+                | wgpu::TextureUsage::TRANSFER_DST,
             format: wgpu::TextureFormat::Bgra8Unorm,
             width: size.width.round() as u32,
             height: size.height.round() as u32,
@@ -125,10 +125,12 @@ fn new_swap_chain(
     let buffer = device.create_texture(&wgpu::TextureDescriptor {
         size: extent,
         dimension: wgpu::TextureDimension::D2,
-        array_size: 1,
+        array_layer_count: 1,
+        mip_level_count: 1,
+        sample_count: 1,
         format: wgpu::TextureFormat::Bgra8UnormSrgb,
-        usage: wgpu::TextureUsageFlags::OUTPUT_ATTACHMENT
-            | wgpu::TextureUsageFlags::TRANSFER_SRC,
+        usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT
+            | wgpu::TextureUsage::TRANSFER_SRC,
     });
 
     let target = Rc::new(buffer.create_default_view());

--- a/src/graphics/backend_wgpu/surface.rs
+++ b/src/graphics/backend_wgpu/surface.rs
@@ -113,6 +113,7 @@ fn new_swap_chain(
             format: wgpu::TextureFormat::Bgra8Unorm,
             width: size.width.round() as u32,
             height: size.height.round() as u32,
+            present_mode: wgpu::PresentMode::Vsync,
         },
     );
 

--- a/src/graphics/backend_wgpu/texture.rs
+++ b/src/graphics/backend_wgpu/texture.rs
@@ -41,8 +41,7 @@ impl Texture {
             width,
             height,
             Some(&[&bgra.into_raw()[..]]),
-            wgpu::TextureUsageFlags::TRANSFER_DST
-                | wgpu::TextureUsageFlags::SAMPLED,
+            wgpu::TextureUsage::TRANSFER_DST | wgpu::TextureUsage::SAMPLED,
         );
 
         Texture {
@@ -75,8 +74,7 @@ impl Texture {
             width,
             height,
             Some(&raw_layers[..]),
-            wgpu::TextureUsageFlags::TRANSFER_DST
-                | wgpu::TextureUsageFlags::SAMPLED,
+            wgpu::TextureUsage::TRANSFER_DST | wgpu::TextureUsage::SAMPLED,
         );
 
         Texture {
@@ -124,8 +122,7 @@ impl Drawable {
             width,
             height,
             None,
-            wgpu::TextureUsageFlags::OUTPUT_ATTACHMENT
-                | wgpu::TextureUsageFlags::SAMPLED,
+            wgpu::TextureUsage::OUTPUT_ATTACHMENT | wgpu::TextureUsage::SAMPLED,
         );
 
         let texture = Texture {
@@ -160,7 +157,7 @@ fn create_texture_array(
     width: u16,
     height: u16,
     layers: Option<&[&[u8]]>,
-    usage: wgpu::TextureUsageFlags,
+    usage: wgpu::TextureUsage,
 ) -> (wgpu::Texture, wgpu::TextureView, quad::TextureBinding) {
     let extent = wgpu::Extent3d {
         width: width as u32,
@@ -172,7 +169,9 @@ fn create_texture_array(
 
     let texture = device.create_texture(&wgpu::TextureDescriptor {
         size: extent,
-        array_size: layer_count,
+        array_layer_count: layer_count,
+        mip_level_count: 1,
+        sample_count: 1,
         dimension: wgpu::TextureDimension::D2,
         format: wgpu::TextureFormat::Bgra8UnormSrgb,
         usage,
@@ -185,10 +184,7 @@ fn create_texture_array(
             layers.iter().cloned().flatten().cloned().collect();
 
         let temp_buf = device
-            .create_buffer_mapped(
-                slice.len(),
-                wgpu::BufferUsageFlags::TRANSFER_SRC,
-            )
+            .create_buffer_mapped(slice.len(), wgpu::BufferUsage::TRANSFER_SRC)
             .fill_from_slice(&slice[..]);
 
         let mut encoder =
@@ -205,8 +201,8 @@ fn create_texture_array(
             },
             wgpu::TextureCopyView {
                 texture: &texture,
-                level: 0,
-                slice: 0,
+                array_layer: 0,
+                mip_level: 0,
                 origin: wgpu::Origin3d {
                     x: 0.0,
                     y: 0.0,

--- a/src/graphics/backend_wgpu/triangle.rs
+++ b/src/graphics/backend_wgpu/triangle.rs
@@ -19,7 +19,7 @@ impl Pipeline {
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                 bindings: &[wgpu::BindGroupLayoutBinding {
                     binding: 0,
-                    visibility: wgpu::ShaderStageFlags::VERTEX,
+                    visibility: wgpu::ShaderStage::VERTEX,
                     ty: wgpu::BindingType::UniformBuffer,
                 }],
             });
@@ -29,8 +29,7 @@ impl Pipeline {
         let transform_buffer = device
             .create_buffer_mapped(
                 16,
-                wgpu::BufferUsageFlags::UNIFORM
-                    | wgpu::BufferUsageFlags::TRANSFER_DST,
+                wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::TRANSFER_DST,
             )
             .fill_from_slice(&matrix[..]);
 
@@ -63,10 +62,10 @@ impl Pipeline {
                     module: &vs_module,
                     entry_point: "main",
                 },
-                fragment_stage: wgpu::PipelineStageDescriptor {
+                fragment_stage: Some(wgpu::PipelineStageDescriptor {
                     module: &fs_module,
                     entry_point: "main",
-                },
+                }),
                 rasterization_state: wgpu::RasterizationStateDescriptor {
                     front_face: wgpu::FrontFace::Ccw,
                     cull_mode: wgpu::CullMode::Back,
@@ -77,31 +76,31 @@ impl Pipeline {
                 primitive_topology: wgpu::PrimitiveTopology::TriangleList,
                 color_states: &[wgpu::ColorStateDescriptor {
                     format: wgpu::TextureFormat::Bgra8UnormSrgb,
-                    color: wgpu::BlendDescriptor {
+                    color_blend: wgpu::BlendDescriptor {
                         src_factor: wgpu::BlendFactor::SrcAlpha,
                         dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
                         operation: wgpu::BlendOperation::Add,
                     },
-                    alpha: wgpu::BlendDescriptor {
+                    alpha_blend: wgpu::BlendDescriptor {
                         src_factor: wgpu::BlendFactor::One,
                         dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
                         operation: wgpu::BlendOperation::Add,
                     },
-                    write_mask: wgpu::ColorWriteFlags::ALL,
+                    write_mask: wgpu::ColorWrite::ALL,
                 }],
                 depth_stencil_state: None,
                 index_format: wgpu::IndexFormat::Uint16,
                 vertex_buffers: &[wgpu::VertexBufferDescriptor {
-                    stride: mem::size_of::<Vertex>() as u32,
+                    stride: mem::size_of::<Vertex>() as u64,
                     step_mode: wgpu::InputStepMode::Vertex,
                     attributes: &[
                         wgpu::VertexAttributeDescriptor {
-                            attribute_index: 0,
+                            shader_location: 0,
                             format: wgpu::VertexFormat::Float2,
                             offset: 0,
                         },
                         wgpu::VertexAttributeDescriptor {
-                            attribute_index: 1,
+                            shader_location: 1,
                             format: wgpu::VertexFormat::Float4,
                             offset: 4 * 2,
                         },
@@ -111,13 +110,13 @@ impl Pipeline {
             });
 
         let vertices = device.create_buffer(&wgpu::BufferDescriptor {
-            size: Self::INITIAL_BUFFER_SIZE,
-            usage: wgpu::BufferUsageFlags::VERTEX,
+            size: Self::INITIAL_BUFFER_SIZE as u64,
+            usage: wgpu::BufferUsage::VERTEX,
         });
 
         let indices = device.create_buffer(&wgpu::BufferDescriptor {
-            size: Self::INITIAL_BUFFER_SIZE,
-            usage: wgpu::BufferUsageFlags::INDEX,
+            size: Self::INITIAL_BUFFER_SIZE as u64,
+            usage: wgpu::BufferUsage::INDEX,
         });
 
         Pipeline {
@@ -146,7 +145,7 @@ impl Pipeline {
         let matrix: [f32; 16] = transformation.clone().into();
 
         let transform_buffer = device
-            .create_buffer_mapped(16, wgpu::BufferUsageFlags::TRANSFER_SRC)
+            .create_buffer_mapped(16, wgpu::BufferUsage::TRANSFER_SRC)
             .fill_from_slice(&matrix[..]);
 
         encoder.copy_buffer_to_buffer(
@@ -163,13 +162,13 @@ impl Pipeline {
             let new_size = vertices.len().max(indices.len()) as u32;
 
             self.vertices = device.create_buffer(&wgpu::BufferDescriptor {
-                size: new_size,
-                usage: wgpu::BufferUsageFlags::VERTEX,
+                size: new_size as u64,
+                usage: wgpu::BufferUsage::VERTEX,
             });
 
             self.indices = device.create_buffer(&wgpu::BufferDescriptor {
-                size: new_size,
-                usage: wgpu::BufferUsageFlags::INDEX,
+                size: new_size as u64,
+                usage: wgpu::BufferUsage::INDEX,
             });
 
             self.buffer_size = new_size;
@@ -178,14 +177,14 @@ impl Pipeline {
         let vertex_buffer = device
             .create_buffer_mapped(
                 vertices.len(),
-                wgpu::BufferUsageFlags::TRANSFER_SRC,
+                wgpu::BufferUsage::TRANSFER_SRC,
             )
             .fill_from_slice(vertices);
 
         let index_buffer = device
             .create_buffer_mapped(
                 indices.len(),
-                wgpu::BufferUsageFlags::TRANSFER_SRC,
+                wgpu::BufferUsage::TRANSFER_SRC,
             )
             .fill_from_slice(indices);
 
@@ -194,7 +193,7 @@ impl Pipeline {
             0,
             &self.vertices,
             0,
-            (mem::size_of::<Vertex>() * vertices.len()) as u32,
+            (mem::size_of::<Vertex>() * vertices.len()) as u64,
         );
 
         encoder.copy_buffer_to_buffer(
@@ -202,7 +201,7 @@ impl Pipeline {
             0,
             &self.indices,
             0,
-            (mem::size_of::<u16>() * indices.len()) as u32,
+            (mem::size_of::<u16>() * indices.len()) as u64,
         );
 
         {
@@ -211,6 +210,7 @@ impl Pipeline {
                     color_attachments: &[
                         wgpu::RenderPassColorAttachmentDescriptor {
                             attachment: target,
+                            resolve_target: None,
                             load_op: wgpu::LoadOp::Load,
                             store_op: wgpu::StoreOp::Store,
                             clear_color: wgpu::Color {
@@ -225,7 +225,7 @@ impl Pipeline {
                 });
 
             render_pass.set_pipeline(&self.pipeline);
-            render_pass.set_bind_group(0, &self.constants);
+            render_pass.set_bind_group(0, &self.constants, &[]);
             render_pass.set_index_buffer(&self.indices, 0);
             render_pass.set_vertex_buffers(&[(&self.vertices, 0)]);
 


### PR DESCRIPTION
Updates the `wgpu` backend to use the latest API. This should help us migrate to the new incoming release.