### PR TITLE
Improve `Task` consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `Task::succeed` replaces the old `Task::new`. [#66]
+
 ### Changed
 - `Mesh::stroke` now takes an `f32` as `line_width` instead of a `u16`.
+- `Task::new` now supports a lazy operation that can fail. [#66]
 
 ### Fixed
 - Incorrect buffer sizes in the `Mesh` pipeline. This caused vertices to entirely
   disappear when rendering big meshes, leading to a potential crash.
+
+[#66]: https://github.com/hecrj/coffee/pull/66
+
 
 ## [0.3.1] - 2019-06-20
 ### Added

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -29,7 +29,7 @@ impl Game for Counter {
     type LoadingScreen = ();
 
     fn load(_window: &Window) -> Task<Counter> {
-        Task::new(|| Counter {
+        Task::succeed(|| Counter {
             value: 0,
             increment_button: button::State::new(),
             decrement_button: button::State::new(),

--- a/examples/gamepad.rs
+++ b/examples/gamepad.rs
@@ -46,7 +46,7 @@ impl Game for GamepadExample {
     type LoadingScreen = ();
 
     fn load(_window: &Window) -> Task<GamepadExample> {
-        Task::new(|| GamepadExample {
+        Task::succeed(|| GamepadExample {
             last_event: "None".to_string(),
         })
     }

--- a/examples/mesh.rs
+++ b/examples/mesh.rs
@@ -55,7 +55,7 @@ impl Game for Example {
     type LoadingScreen = ();
 
     fn load(_window: &Window) -> Task<Example> {
-        Task::new(move || Example {
+        Task::succeed(move || Example {
             shape: ShapeOption::Rectangle,
             mode: ModeOption::Fill,
             color: Color::WHITE,

--- a/examples/particles.rs
+++ b/examples/particles.rs
@@ -41,7 +41,7 @@ impl Particles {
     const CENTER_MASS: f32 = 200.0;
 
     fn generate(max_x: f32, max_y: f32) -> Task<Vec<Particle>> {
-        Task::new(move || {
+        Task::succeed(move || {
             let rng = &mut rand::thread_rng();
 
             (0..Self::AMOUNT)
@@ -76,7 +76,7 @@ impl Game for Particles {
             Task::stage("Loading assets...", Self::load_palette()),
             Task::stage(
                 "Showing off the loading screen for a bit...",
-                Task::new(|| thread::sleep(time::Duration::from_secs(2))),
+                Task::succeed(|| thread::sleep(time::Duration::from_secs(2))),
             ),
         )
             .join()

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -28,7 +28,7 @@ impl Game for Tour {
     type LoadingScreen = ();
 
     fn load(_window: &Window) -> Task<Tour> {
-        Task::new(|| Tour {
+        Task::succeed(|| Tour {
             steps: Steps::new(),
             back_button: button::State::new(),
             next_button: button::State::new(),

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -52,7 +52,7 @@
 //! #   type LoadingScreen = ();
 //! #
 //! #   fn load(window: &Window) -> Task<MyGame> {
-//! #       Task::new(|| MyGame)
+//! #       Task::succeed(|| MyGame)
 //! #   }
 //! #
 //!     // ...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 //!
 //!     fn load(_window: &Window) -> Task<MyGame> {
 //!         // Load your game assets here. Check out the `load` module!
-//!         Task::new(|| MyGame { /* ... */ })
+//!         Task::succeed(|| MyGame { /* ... */ })
 //!     }
 //!
 //!     fn draw(&mut self, frame: &mut Frame, _timer: &Timer) {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -47,7 +47,7 @@
 //! #     type LoadingScreen = ProgressBar;
 //! #
 //! #     fn load(_window: &Window) -> Task<Counter> {
-//! #         Task::new(|| Counter {
+//! #         Task::succeed(|| Counter {
 //! #             value: 0,
 //! #             increment_button: button::State::new(),
 //! #             decrement_button: button::State::new(),


### PR DESCRIPTION
Fixes #61.

### Added
- `Task::succeed` replaces the old `Task::new`.

### Changed
- `Task::new` now supports a lazy operation that can fail.