### PR TITLE
Track more inputs in KeyboardAndMouse

### DIFF
--- a/examples/mesh.rs
+++ b/examples/mesh.rs
@@ -74,7 +74,7 @@ impl Game for Example {
     fn interact(&mut self, input: &mut KeyboardAndMouse, _window: &mut Window) {
         match self.shape {
             ShapeOption::Polyline => {
-                self.polyline_points.extend(input.button_clicks(mouse::Button::Left));
+                self.polyline_points.extend(input.mouse_button_clicks(mouse::Button::Left));
             }
             _ => {}
         }

--- a/examples/mesh.rs
+++ b/examples/mesh.rs
@@ -2,7 +2,7 @@ use coffee::graphics::{
     Color, Frame, HorizontalAlignment, Mesh, Point, Rectangle, Shape, Window,
     WindowSettings,
 };
-use coffee::input::KeyboardAndMouse;
+use coffee::input::{mouse, KeyboardAndMouse};
 use coffee::load::Task;
 use coffee::ui::{
     slider, Align, Column, Element, Justify, Radio, Renderer, Row, Slider,
@@ -74,7 +74,7 @@ impl Game for Example {
     fn interact(&mut self, input: &mut KeyboardAndMouse, _window: &mut Window) {
         match self.shape {
             ShapeOption::Polyline => {
-                self.polyline_points.extend(input.left_clicks());
+                self.polyline_points.extend(input.button_clicks(mouse::Button::Left));
             }
             _ => {}
         }

--- a/examples/particles.rs
+++ b/examples/particles.rs
@@ -9,7 +9,7 @@ use coffee::graphics::{
     Batch, Color, Frame, Image, Point, Rectangle, Sprite, Vector, Window,
     WindowSettings,
 };
-use coffee::input::{keyboard, KeyboardAndMouse};
+use coffee::input::{keyboard, mouse, KeyboardAndMouse};
 use coffee::load::{loading_screen::ProgressBar, Join, Task};
 use coffee::ui::{Checkbox, Column, Element, Justify, Renderer, UserInterface};
 use coffee::{Game, Result, Timer};
@@ -91,7 +91,8 @@ impl Game for Particles {
     fn interact(&mut self, input: &mut KeyboardAndMouse, window: &mut Window) {
         self.gravity_centers[0] = input.cursor_position();
 
-        self.gravity_centers.extend(input.left_clicks());
+        self.gravity_centers
+            .extend(input.button_clicks(mouse::Button::Left));
 
         if input.was_key_released(keyboard::KeyCode::I) {
             self.interpolate = !self.interpolate;

--- a/examples/particles.rs
+++ b/examples/particles.rs
@@ -92,7 +92,7 @@ impl Game for Particles {
         self.gravity_centers[0] = input.cursor_position();
 
         self.gravity_centers
-            .extend(input.button_clicks(mouse::Button::Left));
+            .extend(input.mouse_button_clicks(mouse::Button::Left));
 
         if input.was_key_released(keyboard::KeyCode::I) {
             self.interpolate = !self.interpolate;

--- a/src/input/keyboard_and_mouse.rs
+++ b/src/input/keyboard_and_mouse.rs
@@ -1,7 +1,7 @@
 use super::{keyboard, mouse, ButtonState, Event, Input};
 use crate::graphics::Point;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 /// A simple keyboard and mouse input tracker.
 ///
@@ -11,17 +11,24 @@ use std::collections::HashSet;
 #[derive(Debug)]
 pub struct KeyboardAndMouse {
     cursor_position: Point,
+    mouse_wheel: Point,
     is_cursor_taken: bool,
-    is_mouse_pressed: bool,
-    left_clicks: Vec<Point>,
+    is_cursor_within_game_window: bool,
+    button_clicks: HashMap<mouse::Button, Vec<Point>>,
     pressed_keys: HashSet<keyboard::KeyCode>,
     released_keys: HashSet<keyboard::KeyCode>,
+    pressed_buttons: HashSet<mouse::Button>,
 }
 
 impl KeyboardAndMouse {
     /// Returns the current cursor position.
     pub fn cursor_position(&self) -> Point {
         self.cursor_position
+    }
+
+    /// Returns the mouse wheel movements during the last interaction.
+    pub fn mouse_wheel(&self) -> Point {
+        self.mouse_wheel
     }
 
     /// Returns true if the cursor is currently not available.
@@ -34,12 +41,9 @@ impl KeyboardAndMouse {
         self.is_cursor_taken
     }
 
-    /// Returns the positions of the mouse clicks during the last interaction.
-    ///
-    /// Clicks performed while the mouse cursor is not available are
-    /// automatically ignored.
-    pub fn left_clicks(&self) -> &[Point] {
-        &self.left_clicks
+    /// Returns true if the cursor is currently within the game window.
+    pub fn is_cursor_within_game_window(&self) -> bool {
+        self.is_cursor_within_game_window
     }
 
     /// Returns true if the given key is currently pressed.
@@ -51,17 +55,35 @@ impl KeyboardAndMouse {
     pub fn was_key_released(&self, key_code: keyboard::KeyCode) -> bool {
         self.released_keys.contains(&key_code)
     }
+
+    /// Returns true if the given button is currently pressed.
+    pub fn is_button_pressed(&self, button: mouse::Button) -> bool {
+        self.pressed_buttons.contains(&button)
+    }
+
+    /// Returns the positions of the mouse clicks during the last interaction.
+    ///
+    /// Clicks performed while the mouse cursor is not available are
+    /// automatically ignored.
+    pub fn button_clicks(&self, button: mouse::Button) -> &[Point] {
+        self.button_clicks
+            .get(&button)
+            .map(|v| &v[..])
+            .unwrap_or(&[])
+    }
 }
 
 impl Input for KeyboardAndMouse {
     fn new() -> KeyboardAndMouse {
         KeyboardAndMouse {
             cursor_position: Point::new(0.0, 0.0),
+            mouse_wheel: Point::new(0.0, 0.0),
             is_cursor_taken: false,
-            is_mouse_pressed: false,
-            left_clicks: Vec::new(),
+            is_cursor_within_game_window: false,
+            button_clicks: HashMap::new(),
             pressed_keys: HashSet::new(),
             released_keys: HashSet::new(),
+            pressed_buttons: HashSet::new(),
         }
     }
 
@@ -77,32 +99,36 @@ impl Input for KeyboardAndMouse {
                 mouse::Event::CursorReturned => {
                     self.is_cursor_taken = false;
                 }
-                mouse::Event::Input {
-                    button: mouse::Button::Left,
-                    state,
-                } => match state {
-                    ButtonState::Pressed => {
-                        self.is_mouse_pressed = !self.is_cursor_taken;
-                    }
-                    ButtonState::Released => {
-                        if !self.is_cursor_taken && self.is_mouse_pressed {
-                            self.left_clicks.push(self.cursor_position);
+                mouse::Event::Input { state, button } => {
+                    match state {
+                        ButtonState::Pressed => {
+                            if self.is_cursor_taken {
+                                let _ = self.pressed_buttons.insert(button);
+                            }
                         }
+                        ButtonState::Released => {
+                            if self.is_cursor_taken
+                                && self.is_button_pressed(button)
+                            {
+                                self.button_clicks
+                                    .entry(button)
+                                    .or_insert_with(|| Vec::new())
+                                    .push(self.cursor_position);
+                            }
 
-                        self.is_mouse_pressed = false;
-                    }
-                },
-                mouse::Event::Input { .. } => {
-                    // TODO: Track other buttons!
+                            let _ = self.pressed_buttons.remove(&button);
+                        }
+                    };
                 }
                 mouse::Event::CursorEntered => {
-                    // TODO: Track it!
+                    self.is_cursor_within_game_window = true;
                 }
                 mouse::Event::CursorLeft => {
-                    // TODO: Track it!
+                    self.is_cursor_within_game_window = false;
                 }
-                mouse::Event::WheelScrolled { .. } => {
-                    // TODO: Track it!
+                mouse::Event::WheelScrolled { delta_x, delta_y } => {
+                    self.mouse_wheel.x += delta_x;
+                    self.mouse_wheel.y += delta_y;
                 }
             },
             Event::Keyboard(keyboard_event) => match keyboard_event {
@@ -129,7 +155,9 @@ impl Input for KeyboardAndMouse {
     }
 
     fn clear(&mut self) {
-        self.left_clicks.clear();
+        self.button_clicks.values_mut().for_each(|v| v.clear());
         self.released_keys.clear();
+        self.mouse_wheel.x = 0.0;
+        self.mouse_wheel.y = 0.0;
     }
 }

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -1,6 +1,8 @@
 //! Listen to mouse events.
 
 mod event;
+mod wheel_movement;
 
 pub use crate::graphics::window::winit::MouseButton as Button;
 pub use event::Event;
+pub use wheel_movement::WheelMovement;

--- a/src/input/mouse/wheel_movement.rs
+++ b/src/input/mouse/wheel_movement.rs
@@ -1,0 +1,19 @@
+/// Movement of a mouse wheel
+#[derive(Debug, Copy, Clone)]
+pub struct WheelMovement {
+    /// The number of horizontal lines scrolled
+    pub horizontal: f32,
+
+    /// The number of vertical lines scrolled
+    pub vertical: f32,
+}
+
+impl WheelMovement {
+    /// Creates a new WheelMovement
+    pub fn new(horizontal: f32, vertical: f32) -> Self {
+        WheelMovement {
+            horizontal,
+            vertical,
+        }
+    }
+}


### PR DESCRIPTION
Implementation for #64 

Now KeyboardAndMouse can 
- Handle other mouse buttons than Left
- Track mouse wheel movements
- Detect cursor leaving game window

I decided against keeping the old interface so this is a breaking change.
Is it correct / convenient to track the mouse wheel movements as a point?