### PR TITLE
Implement a `ProgressBar` widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+*.DS_Store

--- a/examples/progress.rs
+++ b/examples/progress.rs
@@ -4,7 +4,7 @@ use coffee::graphics::{
 };
 use coffee::load::Task;
 use coffee::ui::{
-    button, Align, Button, Column, Element, Justify, Renderer, Text,
+    Align, Column, Element, Justify, Renderer, Text,
     UserInterface, ProgressBar,
 };
 use coffee::{Game, Result, Timer};
@@ -72,6 +72,7 @@ impl UserInterface for Progress {
             )
             .push(
                 ProgressBar::new(self.value)
+                    .width(400),
             )
             .into()
     }

--- a/examples/progress.rs
+++ b/examples/progress.rs
@@ -1,0 +1,78 @@
+use coffee::graphics::{
+    Color, Frame, HorizontalAlignment, VerticalAlignment, Window,
+    WindowSettings,
+};
+use coffee::load::Task;
+use coffee::ui::{
+    button, Align, Button, Column, Element, Justify, Renderer, Text,
+    UserInterface, ProgressBar,
+};
+use coffee::{Game, Result, Timer};
+
+pub fn main() -> Result<()> {
+    <Progress as UserInterface>::run(WindowSettings {
+        title: String::from("Progress - Coffee"),
+        size: (1280, 1024),
+        resizable: false,
+        fullscreen: false,
+    })
+}
+
+struct Progress {
+    value: f32,
+}
+
+impl Game for Progress {
+    type Input = ();
+    type LoadingScreen = ();
+
+    fn load(_window: &Window) -> Task<Progress> {
+        Task::succeed(|| Progress {
+            value: 0.0,
+        })
+    }
+
+    fn draw(&mut self, frame: &mut Frame, timer: &Timer) {
+        frame.clear(Color {
+            r: 0.3,
+            g: 0.3,
+            b: 0.6,
+            a: 1.0,
+        });
+
+        if timer.has_ticked() {
+            if self.value >= 1.0 {
+                self.value = 0.0;
+            }
+            self.value += 0.002;
+        }
+    }
+}
+
+impl UserInterface for Progress {
+    type Message = ();
+    type Renderer = Renderer;
+
+    fn react(&mut self, _message: ()) {
+    }
+
+    fn layout(&mut self, window: &Window) -> Element<()> {
+        Column::new()
+            .width(window.width() as u32)
+            .height(window.height() as u32)
+            .align_items(Align::Center)
+            .justify_content(Justify::Center)
+            .spacing(20)
+            .push(
+                Text::new(&format!("{:.0}%", self.value * 100.0))
+                    .size(50)
+                    .height(60)
+                    .horizontal_alignment(HorizontalAlignment::Center)
+                    .vertical_alignment(VerticalAlignment::Center),
+            )
+            .push(
+                ProgressBar::new(self.value)
+            )
+            .into()
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -144,7 +144,7 @@ pub mod widget;
 #[doc(no_inline)]
 pub use self::core::{Align, Justify};
 pub use renderer::{Configuration, Renderer};
-pub use widget::{button, slider, Button, Checkbox, Radio, Slider, Text};
+pub use widget::{button, slider, Button, Checkbox, Radio, Slider, Text, progress_bar, ProgressBar};
 
 /// A [`Column`] using the built-in [`Renderer`].
 ///

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -1,5 +1,6 @@
 mod button;
 mod checkbox;
+mod progress_bar;
 mod radio;
 mod slider;
 mod text;

--- a/src/ui/renderer/progress_bar.rs
+++ b/src/ui/renderer/progress_bar.rs
@@ -1,0 +1,105 @@
+use crate::graphics::{Rectangle, Sprite, Point};
+use crate::ui::{progress_bar, Renderer};
+
+const LEFT: Rectangle<u16> = Rectangle {
+    x: 0,
+    y: 34,
+    width: 6,
+    height: 49,
+};
+
+const BACKGROUND: Rectangle<u16> = Rectangle {
+    x: LEFT.width,
+    y: LEFT.y,
+    width: 1,
+    height: LEFT.height,
+};
+
+const RIGHT: Rectangle<u16> = Rectangle {
+    x: LEFT.height - LEFT.width,
+    y: LEFT.y,
+    width: LEFT.width,
+    height: LEFT.height,
+};
+
+impl progress_bar::Renderer for Renderer {
+    fn draw(
+        &mut self,
+        bounds: Rectangle<f32>,
+        progress: f32,
+    ) {
+        let active_class = 0;
+        let background_class = 1;
+        let full = 1.0;
+        let left_width_f32 = LEFT.width as f32 / 100.0;
+        let background_width = 1.0 - 2.0 * left_width_f32;
+
+        self.sprites.add(left_sprite(bounds, background_class, full));
+        self.sprites.add(background_sprite(bounds, background_class, full));
+        self.sprites.add(right_sprite(bounds, background_class, full));
+
+        if progress > 0.0 {
+            let area = bound(progress / left_width_f32);
+            self.sprites.add(left_sprite(bounds, active_class, area));
+        }
+
+        if progress > left_width_f32 {
+            let area = bound((progress - left_width_f32) / background_width);
+            self.sprites.add(background_sprite(bounds, active_class, area));
+        }
+
+        if progress > left_width_f32 + background_width {
+            let area = bound((progress - left_width_f32 - background_width) / left_width_f32);
+            self.sprites.add(right_sprite(bounds, active_class, area));
+        }
+    }
+}
+
+fn bound(v: f32) -> f32 {
+    if v > 1.0 {
+        1.0
+    } else {
+        v
+    }
+}
+
+fn left_sprite(bounds: Rectangle<f32>, class_index: u16, area: f32) -> Sprite {
+    Sprite {
+        source: Rectangle {
+            x: LEFT.x,
+            y: LEFT.y + class_index * LEFT.height,
+            width: (LEFT.width as f32 * area) as u16,
+            height: LEFT.height,
+        },
+        position: Point::new(bounds.x, bounds.y),
+        scale: (1.0, 1.0),
+    }
+}
+
+fn background_sprite(bounds: Rectangle<f32>, class_index: u16, area: f32) -> Sprite {
+    Sprite {
+        source: Rectangle {
+            x: BACKGROUND.x,
+            y: BACKGROUND.y + class_index * BACKGROUND.height,
+            ..BACKGROUND
+        },
+        position: Point::new(bounds.x + LEFT.width as f32, bounds.y),
+        scale: ((bounds.width - (LEFT.width + RIGHT.width) as f32) * area, 1.0),
+    }
+}
+
+fn right_sprite(bounds: Rectangle<f32>, class_index: u16, area: f32) -> Sprite {
+    Sprite {
+        source: Rectangle {
+            x: RIGHT.x,
+            y: RIGHT.y + class_index * RIGHT.height,
+            width: (RIGHT.width as f32 * area) as u16,
+            height: RIGHT.height,
+        },
+        position: Point::new(
+            bounds.x + bounds.width - RIGHT.width as f32,
+            bounds.y,
+        ),
+        scale: (1.0, 1.0),
+    }
+}

--- a/src/ui/widget.rs
+++ b/src/ui/widget.rs
@@ -27,6 +27,7 @@ mod row;
 
 pub mod button;
 pub mod checkbox;
+pub mod progress_bar;
 pub mod radio;
 pub mod slider;
 pub mod text;
@@ -34,6 +35,7 @@ pub mod text;
 pub use button::Button;
 pub use checkbox::Checkbox;
 pub use column::Column;
+pub use progress_bar::ProgressBar;
 pub use radio::Radio;
 pub use row::Row;
 pub use slider::Slider;

--- a/src/ui/widget/progress_bar.rs
+++ b/src/ui/widget/progress_bar.rs
@@ -24,7 +24,7 @@ use std::hash::Hash;
 ///
 /// let progress = 0.75;
 ///
-/// ProgressBar::new(progress)
+/// ProgressBar::new(progress);
 /// ```
 #[derive(Debug)]
 pub struct ProgressBar {

--- a/src/ui/widget/progress_bar.rs
+++ b/src/ui/widget/progress_bar.rs
@@ -25,7 +25,6 @@ use std::hash::Hash;
 /// let progress = 0.75;
 ///
 /// ProgressBar::new(progress)
-///     .width(300);
 /// ```
 #[derive(Debug)]
 pub struct ProgressBar {
@@ -40,7 +39,7 @@ impl ProgressBar {
     pub fn new(progress: f32) -> Self {
         ProgressBar {
             progress,
-            style: Style::default().min_width(100),
+            style: Style::default().fill_width(),
         }
     }
 
@@ -73,7 +72,7 @@ where
         &self,
         renderer: &mut Renderer,
         layout: Layout<'_>,
-        cursor_position: Point,
+        _cursor_position: Point,
     ) -> MouseCursor {
         renderer.draw(
             layout.bounds(),

--- a/src/ui/widget/progress_bar.rs
+++ b/src/ui/widget/progress_bar.rs
@@ -1,0 +1,120 @@
+//! Displays action progress to your users.
+
+use crate::graphics::{
+    Point, Rectangle,
+};
+use crate::ui::core::{
+    Style, Node, Element, MouseCursor, Layout, Hasher, Widget,
+};
+
+use std::hash::Hash;
+
+/// A widget that displays a progress of an action.
+/// 
+/// It implements [`Widget`] when the associated [`core::Renderer`] implements
+/// the [`button::Renderer`] trait.
+///
+/// [`Widget`]: ../../core/trait.Widget.html
+/// [`core::Renderer`]: ../../core/trait.Renderer.html
+/// [`progress_bar::Renderer`]: trait.Renderer.html
+/// # Example
+///
+/// ```
+/// use coffee::ui::ProgressBar;
+///
+/// let progress = 0.75;
+///
+/// ProgressBar::new(progress)
+///     .width(300);
+/// ```
+#[derive(Debug)]
+pub struct ProgressBar {
+    progress: f32,
+    style: Style,
+}
+
+impl ProgressBar {
+    /// Creates a new [`ProgressBar`] with given progress.
+    ///
+    /// [`ProgressBar`]: struct.ProgressBar.html
+    pub fn new(progress: f32) -> Self {
+        ProgressBar {
+            progress,
+            style: Style::default().min_width(100),
+        }
+    }
+
+    /// Sets the width of the [`ProgressBar`] in pixels.
+    ///
+    /// [`ProgressBar`]: struct.ProgressBar.html
+    pub fn width(mut self, width: u32) -> Self {
+        self.style = self.style.width(width);
+        self
+    }
+
+    /// Makes the [`ProgressBar`] fill the horizontal space of its container.
+    ///
+    /// [`ProgressBar`]: struct.ProgressBar.html
+    pub fn fill_width(mut self) -> Self {
+        self.style = self.style.fill_width();
+        self
+    }
+}
+
+impl<Message, Renderer> Widget<Message, Renderer> for ProgressBar
+where
+    Renderer: self::Renderer 
+{
+    fn node(&self, _renderer: &Renderer) -> Node {
+        Node::new(self.style.height(50))
+    }
+
+    fn draw(
+        &self,
+        renderer: &mut Renderer,
+        layout: Layout<'_>,
+        cursor_position: Point,
+    ) -> MouseCursor {
+        renderer.draw(
+            layout.bounds(),
+            self.progress,
+        );
+
+        MouseCursor::OutOfBounds
+    }
+
+    fn hash(&self, state: &mut Hasher) {
+        self.style.hash(state);
+    }
+}
+
+/// The renderer of a [`ProgressBar`].
+///
+/// Your [`core::Renderer`] will need to implement this trait before being
+/// able to use a [`ProgressBar`] in your user interface.
+///
+/// [`ProgressBar`]: struct.ProgressBar.html
+/// [`core::Renderer`]: ../../core/trait.Renderer.html
+pub trait Renderer {
+    /// Draws a [`ProgressBar`].
+    ///
+    /// It receives:
+    ///   * the bounds of the [`ProgressBar`]
+    ///   * the progress of the [`ProgressBar`]
+    ///   
+    /// [`ProgressBar`]: struct.ProgressBar.html
+    fn draw(
+        &mut self,
+        bounds: Rectangle<f32>,
+        progress: f32,
+    );
+}
+
+impl<'a, Message, Renderer> From<ProgressBar> for Element<'a, Message, Renderer>
+where
+    Renderer: self::Renderer,
+{
+    fn from(progress_bar: ProgressBar) -> Element<'a, Message, Renderer> {
+        Element::new(progress_bar)
+    }
+}


### PR DESCRIPTION
closes #45

Added `ProgressBar` widget and `progress` example. 
<img width="752" alt="Screenshot 2019-08-16 at 19 44 15" src="https://user-images.githubusercontent.com/2613714/63187375-0633e080-c05f-11e9-9b85-d1c21bee376d.png">

I decided to reuse button sprites for now, but this can be easily changed in future if needed.
