### PR TITLE
Fix example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ impl Game for MyGame {
 
     fn load(_window: &Window) -> Task<MyGame> {
         // Load your game assets here. Check out the `load` module!
-        Task::succeed(|| MyGame { /* ... */ })
+        Task::new(|| MyGame { /* ... */ })
     }
 
     fn draw(&mut self, frame: &mut Frame, _timer: &Timer) {


### PR DESCRIPTION
fixes the example for coffee 0.3.
It's correct in the docs but not in the readme.