### PR TITLE
Promote `Mesh` indices from `u16` to `u32`

### DIFF
--- a/src/graphics/backend_gfx/mod.rs
+++ b/src/graphics/backend_gfx/mod.rs
@@ -124,7 +124,7 @@ impl Gpu {
     pub(super) fn draw_triangles(
         &mut self,
         vertices: &[Vertex],
-        indices: &[u16],
+        indices: &[u32],
         view: &TargetView,
         transformation: &Transformation,
     ) {

--- a/src/graphics/backend_gfx/triangle.rs
+++ b/src/graphics/backend_gfx/triangle.rs
@@ -30,7 +30,7 @@ gfx_defines! {
 
 pub struct Pipeline {
     data: pipe::Data<gl::Resources>,
-    indices: gfx::handle::Buffer<gl::Resources, u16>,
+    indices: gfx::handle::Buffer<gl::Resources, u32>,
     shader: Shader,
     globals: Globals,
 }
@@ -100,7 +100,7 @@ impl Pipeline {
         factory: &mut gl::Factory,
         encoder: &mut gfx::Encoder<gl::Resources, gl::CommandBuffer>,
         vertices: &[Vertex],
-        indices: &[u16],
+        indices: &[u32],
         transformation: &Transformation,
         view: &gfx::handle::RawRenderTargetView<gl::Resources>,
     ) {
@@ -122,7 +122,7 @@ impl Pipeline {
         {
             let vertices = factory
                 .create_buffer(
-                    Self::INITIAL_BUFFER_SIZE,
+                    self.data.vertices.len(),
                     gfx::buffer::Role::Vertex,
                     gfx::memory::Usage::Dynamic,
                     gfx::memory::Bind::SHADER_RESOURCE,
@@ -131,7 +131,7 @@ impl Pipeline {
 
             let indices = factory
                 .create_buffer(
-                    Self::INITIAL_BUFFER_SIZE,
+                    indices.len(),
                     gfx::buffer::Role::Index,
                     gfx::memory::Usage::Dynamic,
                     gfx::memory::Bind::empty(),
@@ -155,7 +155,7 @@ impl Pipeline {
             end: indices.len() as u32,
             base_vertex: 0,
             instances: None,
-            buffer: gfx::IndexBuffer::Index16(self.indices.clone()),
+            buffer: gfx::IndexBuffer::Index32(self.indices.clone()),
         };
 
         encoder.draw(&slice, &self.shader.state, &self.data);

--- a/src/graphics/backend_wgpu/mod.rs
+++ b/src/graphics/backend_wgpu/mod.rs
@@ -122,7 +122,7 @@ impl Gpu {
     pub(super) fn draw_triangles(
         &mut self,
         vertices: &[Vertex],
-        indices: &[u16],
+        indices: &[u32],
         view: &TargetView,
         transformation: &Transformation,
     ) {

--- a/src/graphics/backend_wgpu/triangle.rs
+++ b/src/graphics/backend_wgpu/triangle.rs
@@ -89,7 +89,7 @@ impl Pipeline {
                     write_mask: wgpu::ColorWrite::ALL,
                 }],
                 depth_stencil_state: None,
-                index_format: wgpu::IndexFormat::Uint16,
+                index_format: wgpu::IndexFormat::Uint32,
                 vertex_buffers: &[wgpu::VertexBufferDescriptor {
                     stride: mem::size_of::<Vertex>() as u64,
                     step_mode: wgpu::InputStepMode::Vertex,
@@ -116,7 +116,8 @@ impl Pipeline {
         });
 
         let indices = device.create_buffer(&wgpu::BufferDescriptor {
-            size: Self::INITIAL_BUFFER_SIZE as u64 * 2,
+            size: mem::size_of::<u32>() as u64
+                * Self::INITIAL_BUFFER_SIZE as u64,
             usage: wgpu::BufferUsage::INDEX | wgpu::BufferUsage::TRANSFER_DST,
         });
 
@@ -135,7 +136,7 @@ impl Pipeline {
         device: &mut wgpu::Device,
         encoder: &mut wgpu::CommandEncoder,
         vertices: &[Vertex],
-        indices: &[u16],
+        indices: &[u32],
         transformation: &Transformation,
         target: &wgpu::TextureView,
     ) {
@@ -169,7 +170,7 @@ impl Pipeline {
             });
 
             self.indices = device.create_buffer(&wgpu::BufferDescriptor {
-                size: new_size as u64 * 2,
+                size: mem::size_of::<u32>() as u64 * new_size as u64,
                 usage: wgpu::BufferUsage::INDEX
                     | wgpu::BufferUsage::TRANSFER_DST,
             });
@@ -204,7 +205,7 @@ impl Pipeline {
             0,
             &self.indices,
             0,
-            (mem::size_of::<u16>() * indices.len()) as u64,
+            (mem::size_of::<u32>() * indices.len()) as u64,
         );
 
         {

--- a/src/graphics/mesh.rs
+++ b/src/graphics/mesh.rs
@@ -5,7 +5,7 @@ use lyon_tessellation as lyon;
 /// A set of shapes that can be drawn.
 #[derive(Debug, Clone)]
 pub struct Mesh {
-    buffers: lyon::VertexBuffers<gpu::Vertex, u16>,
+    buffers: lyon::VertexBuffers<gpu::Vertex, u32>,
 }
 
 impl Mesh {

--- a/src/graphics/target.rs
+++ b/src/graphics/target.rs
@@ -98,7 +98,7 @@ impl<'a> Target<'a> {
     pub(super) fn draw_triangles(
         &mut self,
         vertices: &[Vertex],
-        indices: &[u16],
+        indices: &[u32],
     ) {
         self.gpu.draw_triangles(
             vertices,


### PR DESCRIPTION
Fixes #87.

It also fixes a crash when rendering big meshes in OpenGL.