### PR TITLE
Fix hang when `Game::TICKS_PER_SECOND` is `0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,12 +38,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - wheel movements [#67]
     - the cursor leaving/entering the game window [#67]
 
+### Fixed
+- Hang when `Game::TICKS_PER_SECOND` is set as `0`. [#99]
+
 [#66]: https://github.com/hecrj/coffee/pull/66
 [#67]: https://github.com/hecrj/coffee/pull/67
 [#69]: https://github.com/hecrj/coffee/pull/69
 [#77]: https://github.com/hecrj/coffee/pull/77
 [#78]: https://github.com/hecrj/coffee/pull/78
 [#79]: https://github.com/hecrj/coffee/pull/79
+[#99]: https://github.com/hecrj/coffee/pull/99
 
 
 ## [0.3.2] - 2019-09-01

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -18,16 +18,15 @@ pub struct Timer {
 
 impl Timer {
     pub(crate) fn new(ticks_per_second: u16) -> Timer {
-        let target = 1.0 / ticks_per_second as f64;
-        let target_seconds = target.trunc();
-        let target_nanos = target.fract() * 1e9;
+        let (target_seconds, target_nanos) = match ticks_per_second {
+            0 => (std::u64::MAX, 0),
+            1 => (1, 0),
+            _ => (0, ((1.0 / ticks_per_second as f64).fract() * 1e9) as u32),
+        };
 
         Timer {
             target_ticks: ticks_per_second,
-            target_delta: time::Duration::new(
-                target_seconds as u64,
-                target_nanos as u32,
-            ),
+            target_delta: time::Duration::new(target_seconds, target_nanos),
             last_tick: time::Instant::now(),
             accumulated_delta: time::Duration::from_secs(0),
             has_ticked: false,

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -21,7 +21,7 @@ impl Timer {
         let (target_seconds, target_nanos) = match ticks_per_second {
             0 => (std::u64::MAX, 0),
             1 => (1, 0),
-            _ => (0, ((1.0 / ticks_per_second as f64).fract() * 1e9) as u32),
+            _ => (0, ((1.0 / ticks_per_second as f64) * 1e9) as u32),
         };
 
         Timer {


### PR DESCRIPTION
Fixes #96.

The game will still tick in this case after approximately __`584942417355.072` years__ in most platforms. I think this is acceptable.