### PR TITLE
Mesh with custom tolerance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   performing a slow task.
 - `ui::Image`, a simple widget to display a `graphics::Image` in your user
   interface.
+- `Mesh::new_with_tolerance`, which allows to control the tolerance of line
+  segment approximations. [#100]
 
 ### Changed
 - `Mesh::stroke` now takes an `f32` as `line_width` instead of a `u16`.
@@ -37,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - any button click [#67]
     - wheel movements [#67]
     - the cursor leaving/entering the game window [#67]
+- The `mesh` example now has a slider to control the tolerance. [#100]
 
 ### Fixed
 - Hang when `Game::TICKS_PER_SECOND` is set as `0`. [#99]
@@ -48,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#78]: https://github.com/hecrj/coffee/pull/78
 [#79]: https://github.com/hecrj/coffee/pull/79
 [#99]: https://github.com/hecrj/coffee/pull/99
+[#100]: https://github.com/hecrj/coffee/pull/100
 
 
 ## [0.3.2] - 2019-09-01

--- a/examples/mesh.rs
+++ b/examples/mesh.rs
@@ -24,12 +24,14 @@ fn main() -> Result<()> {
 struct Example {
     shape: ShapeOption,
     mode: ModeOption,
+    tolerance: f32,
     stroke_width: u16,
     radius: f32,
     vertical_radius: f32,
     color: Color,
     polyline_points: Vec<Point>,
 
+    tolerance_slider: slider::State,
     stroke_width_slider: slider::State,
     radius_slider: slider::State,
     vertical_radius_slider: slider::State,
@@ -58,12 +60,14 @@ impl Game for Example {
         Task::succeed(move || Example {
             shape: ShapeOption::Rectangle,
             mode: ModeOption::Fill,
+            tolerance: 0.1,
             color: Color::WHITE,
             radius: 100.0,
             vertical_radius: 50.0,
             stroke_width: 2,
             polyline_points: Vec::new(),
 
+            tolerance_slider: slider::State::new(),
             stroke_width_slider: slider::State::new(),
             radius_slider: slider::State::new(),
             vertical_radius_slider: slider::State::new(),
@@ -89,7 +93,7 @@ impl Game for Example {
             a: 1.0,
         });
 
-        let mut mesh = Mesh::new();
+        let mut mesh = Mesh::new_with_tolerance(self.tolerance);
 
         let shape = match self.shape {
             ShapeOption::Rectangle => Shape::Rectangle(Rectangle {
@@ -137,6 +141,9 @@ impl UserInterface for Example {
             }
             Message::ModeSelected(mode) => {
                 self.mode = mode;
+            }
+            Message::ToleranceChanged(tolerance) => {
+                self.tolerance = tolerance;
             }
             Message::StrokeWidthChanged(stroke_width) => {
                 self.stroke_width = stroke_width;
@@ -206,8 +213,9 @@ impl UserInterface for Example {
             }
         }
 
-        controls =
-            controls.push(color_sliders(&mut self.color_sliders, self.color));
+        controls = controls
+            .push(color_sliders(&mut self.color_sliders, self.color))
+            .push(tolerance_slider(&mut self.tolerance_slider, self.tolerance));
 
         Column::new()
             .width(window.width() as u32)
@@ -225,6 +233,7 @@ impl UserInterface for Example {
 enum Message {
     ShapeSelected(ShapeOption),
     ModeSelected(ModeOption),
+    ToleranceChanged(f32),
     StrokeWidthChanged(u16),
     RadiusChanged(f32),
     VerticalRadiusChanged(f32),
@@ -254,6 +263,20 @@ fn shape_selector(current: ShapeOption) -> Element<'static, Message> {
         .push(Text::new("Shape:"))
         .push(options)
         .into()
+}
+
+fn tolerance_slider(
+    state: &mut slider::State,
+    tolerance: f32,
+) -> Element<Message> {
+    slider_with_label(
+        "Tolerance:",
+        state,
+        0.001..=20.0,
+        tolerance,
+        &format!("{:.*}", 3, tolerance),
+        Message::ToleranceChanged,
+    )
 }
 
 fn mode_selector(current: ModeOption) -> Element<'static, Message> {

--- a/src/graphics/mesh.rs
+++ b/src/graphics/mesh.rs
@@ -3,17 +3,46 @@ use crate::graphics::{gpu, Color, Rectangle, Shape, Target};
 use lyon_tessellation as lyon;
 
 /// A set of shapes that can be drawn.
+///
+/// # Tolerance
+/// When shapes contain curves or arcs, they will be approximated using line
+/// segments. The `tolerance` parameter controls this approximation by
+/// establishing the maximum distance between a curve and its line segments.
+///
+/// The lower the tolerance provided, the better a [`Mesh`] will approximate
+/// a [`Shape`]. However, a lower tolerance can have a noticeable performance
+/// impact. Use it wisely!
+///
+/// [`Mesh`]: struct.Mesh.html
+/// [`Shape`]: enum.Shape.html
 #[derive(Debug, Clone)]
 pub struct Mesh {
+    tolerance: f32,
     buffers: lyon::VertexBuffers<gpu::Vertex, u32>,
 }
 
 impl Mesh {
-    /// Creates a new empty [`Mesh`].
+    /// Creates a new empty [`Mesh`] with a default tolerance of `0.1`.
     ///
     /// [`Mesh`]: struct.Mesh.html
     pub fn new() -> Mesh {
         Mesh {
+            tolerance: 0.1,
+            buffers: lyon::VertexBuffers::new(),
+        }
+    }
+
+    /// Creates a new empty [`Mesh`] with the given tolerance.
+    ///
+    /// Providing a lower tolerance here can allow you to zoom in your [`Mesh`]
+    /// using a [`Transformation`] and still observe smooth curves. See
+    /// [Tolerance](#tolerance).
+    ///
+    /// [`Mesh`]: struct.Mesh.html
+    /// [`Transformation`]: struct.Transformation.html
+    pub fn new_with_tolerance(tolerance: f32) -> Mesh {
+        Mesh {
+            tolerance,
             buffers: lyon::VertexBuffers::new(),
         }
     }
@@ -45,7 +74,7 @@ impl Mesh {
             }) => {
                 let _ = lyon::basic_shapes::fill_rectangle(
                     &lyon::math::rect(x, y, width, height),
-                    &Self::fill_options(),
+                    &Self::fill_options(self.tolerance),
                     &mut builder,
                 )
                 .expect("Fill rectangle");
@@ -54,7 +83,7 @@ impl Mesh {
                 let _ = lyon::basic_shapes::fill_circle(
                     lyon::math::point(center.x, center.y),
                     radius,
-                    &Self::fill_options(),
+                    &Self::fill_options(self.tolerance),
                     &mut builder,
                 )
                 .expect("Fill circle");
@@ -69,7 +98,7 @@ impl Mesh {
                     lyon::math::point(center.x, center.y),
                     lyon::math::vector(horizontal_radius, vertical_radius),
                     lyon::math::Angle::radians(rotation),
-                    &Self::fill_options(),
+                    &Self::fill_options(self.tolerance),
                     &mut builder,
                 )
                 .expect("Fill ellipse");
@@ -80,7 +109,7 @@ impl Mesh {
                         .iter()
                         .map(|point| lyon::math::point(point.x, point.y)),
                     &mut lyon::FillTessellator::new(),
-                    &Self::fill_options(),
+                    &Self::fill_options(self.tolerance),
                     &mut builder,
                 )
                 .expect("Fill polyline");
@@ -108,7 +137,7 @@ impl Mesh {
             }) => {
                 let _ = lyon::basic_shapes::stroke_rectangle(
                     &lyon::math::rect(x, y, rect_width, height),
-                    &Self::stroke_options(width),
+                    &Self::stroke_options(self.tolerance, width),
                     &mut builder,
                 )
                 .expect("Stroke rectangle");
@@ -117,7 +146,7 @@ impl Mesh {
                 let _ = lyon::basic_shapes::stroke_circle(
                     lyon::math::point(center.x, center.y),
                     radius,
-                    &Self::stroke_options(width),
+                    &Self::stroke_options(self.tolerance, width),
                     &mut builder,
                 )
                 .expect("Stroke circle");
@@ -132,7 +161,7 @@ impl Mesh {
                     lyon::math::point(center.x, center.y),
                     lyon::math::vector(horizontal_radius, vertical_radius),
                     lyon::math::Angle::radians(rotation),
-                    &Self::stroke_options(width),
+                    &Self::stroke_options(self.tolerance, width),
                     &mut builder,
                 )
                 .expect("Stroke ellipse");
@@ -143,7 +172,7 @@ impl Mesh {
                         .iter()
                         .map(|point| lyon::math::point(point.x, point.y)),
                     false,
-                    &Self::stroke_options(width),
+                    &Self::stroke_options(self.tolerance, width),
                     &mut builder,
                 )
                 .expect("Stroke polyline");
@@ -159,12 +188,16 @@ impl Mesh {
         target.draw_triangles(&self.buffers.vertices, &self.buffers.indices);
     }
 
-    fn fill_options() -> lyon::FillOptions {
-        lyon::FillOptions::DEFAULT.with_normals(false)
+    fn fill_options(tolerance: f32) -> lyon::FillOptions {
+        lyon::FillOptions::DEFAULT
+            .with_tolerance(tolerance)
+            .with_normals(false)
     }
 
-    fn stroke_options(width: f32) -> lyon::StrokeOptions {
-        lyon::StrokeOptions::DEFAULT.with_line_width(width)
+    fn stroke_options(tolerance: f32, width: f32) -> lyon::StrokeOptions {
+        lyon::StrokeOptions::DEFAULT
+            .with_tolerance(tolerance)
+            .with_line_width(width)
     }
 }
 


### PR DESCRIPTION
Fixes #98.

## Changelog
### Added
- `Mesh::new_with_tolerance`, which allows to control the tolerance of line segment approximations.

### Changed
- The `mesh` example now has a slider to control the tolerance.