### PR TITLE
Make `graphics::Image::from_image` borrow the image buffer

### DIFF
--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -32,7 +32,7 @@ impl Image {
             image::load_from_memory(&buf)?
         };
 
-        Image::from_image(gpu, image)
+        Image::from_image(gpu, &image)
     }
 
     /// Creates a [`Task`] that loads an [`Image`] from the given path.
@@ -52,7 +52,7 @@ impl Image {
     /// [`image` crate]: https://docs.rs/image
     pub fn from_image(
         gpu: &mut Gpu,
-        image: image::DynamicImage,
+        image: &image::DynamicImage,
     ) -> Result<Image> {
         let texture = gpu.upload_texture(&image);
 
@@ -71,7 +71,7 @@ impl Image {
 
         Self::from_image(
             gpu,
-            image::DynamicImage::ImageRgba8(
+            &image::DynamicImage::ImageRgba8(
                 image::RgbaImage::from_raw(
                     colors.len() as u32,
                     1,

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -126,7 +126,7 @@ impl Default for Configuration {
             sprites: Task::using_gpu(|gpu| {
                 Image::from_image(
                     gpu,
-                    ::image::load_from_memory(include_bytes!(
+                    &::image::load_from_memory(include_bytes!(
                         "../../resources/ui.png"
                     ))?,
                 )

--- a/tests/_graphics/test.rs
+++ b/tests/_graphics/test.rs
@@ -114,7 +114,7 @@ impl Drawing {
             .expect("Create diff image");
 
             let image =
-                Image::from_image(gpu, image::DynamicImage::ImageRgba8(image))
+                Image::from_image(gpu, &image::DynamicImage::ImageRgba8(image))
                     .expect("Upload diff image");
 
             Ok(Some(Differences {


### PR DESCRIPTION
This makes it possible to reuse the `DynamicImage` buffer, avoiding unnecessary allocations.