### PR TITLE
Cursor icon support through Game trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   interface.
 - `Mesh::new_with_tolerance`, which allows to control the tolerance of line
   segment approximations. [#100]
+- `Game::cursor_icon`, which allows customization of the mouse cursor icon.
 
 ### Changed
 - `Mesh::stroke` now takes an `f32` as `line_width` instead of a `u16`.

--- a/src/game.rs
+++ b/src/game.rs
@@ -2,7 +2,7 @@ mod r#loop;
 
 pub(crate) use r#loop::Loop;
 
-use crate::graphics::{window::CursorIcon, Frame, Window, WindowSettings};
+use crate::graphics::{CursorIcon, Frame, Window, WindowSettings};
 use crate::input::{keyboard, Input};
 use crate::load::{LoadingScreen, Task};
 use crate::{Debug, Result, Timer};

--- a/src/game.rs
+++ b/src/game.rs
@@ -2,7 +2,7 @@ mod r#loop;
 
 pub(crate) use r#loop::Loop;
 
-use crate::graphics::{Frame, Window, WindowSettings};
+use crate::graphics::{window::CursorIcon, Frame, Window, WindowSettings};
 use crate::input::{keyboard, Input};
 use crate::load::{LoadingScreen, Task};
 use crate::{Debug, Result, Timer};
@@ -123,6 +123,11 @@ pub trait Game {
     /// [`TICKS_PER_SECOND`]: #associatedconstant.TICKS_PER_SECOND
     /// [`Window`]: graphics/struct.Window.html
     fn update(&mut self, _window: &Window) {}
+
+    /// TODO!
+    fn cursor_icon(&self) -> CursorIcon {
+        CursorIcon::Default
+    }
 
     /// Displays debug information.
     ///

--- a/src/game.rs
+++ b/src/game.rs
@@ -124,7 +124,9 @@ pub trait Game {
     /// [`Window`]: graphics/struct.Window.html
     fn update(&mut self, _window: &Window) {}
 
-    /// TODO!
+    /// Defines the cursor icon of the window.
+    ///
+    /// By default, it returns platform-dependent default cursor.
     fn cursor_icon(&self) -> CursorIcon {
         CursorIcon::Default
     }

--- a/src/game/loop.rs
+++ b/src/game/loop.rs
@@ -1,9 +1,10 @@
 use crate::debug::Debug;
 use crate::graphics::window::winit;
-use crate::graphics::{CursorIcon, Window, WindowSettings};
+use crate::graphics::{Window, WindowSettings};
 use crate::input::{self, gamepad, keyboard, mouse, window, Input};
 use crate::load::{Join, LoadingScreen, Task};
 use crate::{Result, Timer};
+use std::convert::TryInto;
 
 pub trait Loop<Game: super::Game> {
     type Attributes;
@@ -231,8 +232,6 @@ where
         window: &mut Window,
         _debug: &mut Debug,
     ) {
-        let cursor_icon = game.cursor_icon();
-        window.set_cursor_visible(cursor_icon != CursorIcon::Hidden);
-        window.update_cursor(cursor_icon.into());
+        window.update_cursor(game.cursor_icon().try_into().ok());
     }
 }

--- a/src/game/loop.rs
+++ b/src/game/loop.rs
@@ -204,9 +204,7 @@ fn try_into_input_event(
     }
 }
 
-pub struct Default {
-    cursor_icon: CursorIcon,
-}
+pub struct Default {}
 
 impl<Game: super::Game> Loop<Game> for Default
 where
@@ -219,9 +217,7 @@ where
         _game: &mut Game,
         _window: &Window,
     ) -> Self {
-        Self {
-            cursor_icon: CursorIcon::default(),
-        }
+        Self {}
     }
 
     fn load(_window: &Window) -> Task<Self::Attributes> {
@@ -235,12 +231,8 @@ where
         window: &mut Window,
         _debug: &mut Debug,
     ) {
-        // Update the cursor icon if it has changed
-        let game_cursor_icon = game.cursor_icon();
-        if self.cursor_icon != game_cursor_icon {
-            window.set_cursor_visible(game_cursor_icon != CursorIcon::Hidden);
-            window.update_cursor(game_cursor_icon.into());
-            self.cursor_icon = game_cursor_icon;
-        }
+        let cursor_icon = game.cursor_icon();
+        window.set_cursor_visible(cursor_icon != CursorIcon::Hidden);
+        window.update_cursor(cursor_icon.into());
     }
 }

--- a/src/game/loop.rs
+++ b/src/game/loop.rs
@@ -1,5 +1,5 @@
 use crate::debug::Debug;
-use crate::graphics::window::winit;
+use crate::graphics::window::{winit, CursorIcon};
 use crate::graphics::{Window, WindowSettings};
 use crate::input::{self, gamepad, keyboard, mouse, window, Input};
 use crate::load::{Join, LoadingScreen, Task};
@@ -96,6 +96,10 @@ pub trait Loop<Game: super::Game> {
                 debug.draw_started();
                 game.draw(&mut window.frame(), &timer);
                 debug.draw_finished();
+
+                let cursor_icon = game.cursor_icon();
+                window.set_cursor_visible(cursor_icon != CursorIcon::Hidden);
+                window.update_cursor(cursor_icon.into());
 
                 game_loop.after_draw(
                     &mut game,

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -141,4 +141,4 @@ pub use text::{HorizontalAlignment, Text, VerticalAlignment};
 pub use texture_array::TextureArray;
 pub use transformation::Transformation;
 pub use vector::Vector;
-pub use window::{Frame, Settings as WindowSettings, Window};
+pub use window::{CursorIcon, Frame, Settings as WindowSettings, Window};

--- a/src/graphics/window.rs
+++ b/src/graphics/window.rs
@@ -1,8 +1,10 @@
+mod cursor_icon;
 mod frame;
 mod settings;
 
 pub(crate) use winit;
 
+pub use cursor_icon::CursorIcon;
 pub use frame::Frame;
 pub use settings::Settings;
 
@@ -134,6 +136,10 @@ impl Window {
         new_cursor: winit::window::CursorIcon,
     ) {
         self.surface.window().set_cursor_icon(new_cursor);
+    }
+
+    pub(crate) fn set_cursor_visible(&self, visible: bool) {
+        self.surface.window().set_cursor_visible(visible);
     }
 }
 

--- a/src/graphics/window.rs
+++ b/src/graphics/window.rs
@@ -22,6 +22,8 @@ pub struct Window {
     width: f32,
     height: f32,
     is_fullscreen: bool,
+    cursor_icon: winit::window::CursorIcon,
+    cursor_visible: bool,
 }
 
 impl Window {
@@ -62,6 +64,8 @@ impl Window {
             surface,
             width,
             height,
+            cursor_icon: winit::window::CursorIcon::Default,
+            cursor_visible: true,
         })
     }
 
@@ -135,11 +139,17 @@ impl Window {
         &mut self,
         new_cursor: winit::window::CursorIcon,
     ) {
-        self.surface.window().set_cursor_icon(new_cursor);
+        if self.cursor_icon != new_cursor {
+            self.surface.window().set_cursor_icon(new_cursor);
+            self.cursor_icon = new_cursor;
+        }
     }
 
-    pub(crate) fn set_cursor_visible(&self, visible: bool) {
-        self.surface.window().set_cursor_visible(visible);
+    pub(crate) fn set_cursor_visible(&mut self, visible: bool) {
+        if self.cursor_visible != visible {
+            self.surface.window().set_cursor_visible(visible);
+            self.cursor_visible = visible;
+        }
     }
 }
 

--- a/src/graphics/window.rs
+++ b/src/graphics/window.rs
@@ -22,8 +22,7 @@ pub struct Window {
     width: f32,
     height: f32,
     is_fullscreen: bool,
-    cursor_icon: winit::window::CursorIcon,
-    cursor_visible: bool,
+    cursor_icon: Option<winit::window::CursorIcon>,
 }
 
 impl Window {
@@ -64,8 +63,7 @@ impl Window {
             surface,
             width,
             height,
-            cursor_icon: winit::window::CursorIcon::Default,
-            cursor_visible: true,
+            cursor_icon: Some(winit::window::CursorIcon::Default),
         })
     }
 
@@ -137,18 +135,16 @@ impl Window {
 
     pub(crate) fn update_cursor(
         &mut self,
-        new_cursor: winit::window::CursorIcon,
+        new_cursor: Option<winit::window::CursorIcon>,
     ) {
         if self.cursor_icon != new_cursor {
-            self.surface.window().set_cursor_icon(new_cursor);
+            if let Some(cursor_icon) = new_cursor {
+                self.surface.window().set_cursor_icon(cursor_icon);
+            }
+            self.surface
+                .window()
+                .set_cursor_visible(new_cursor.is_some());
             self.cursor_icon = new_cursor;
-        }
-    }
-
-    pub(crate) fn set_cursor_visible(&mut self, visible: bool) {
-        if self.cursor_visible != visible {
-            self.surface.window().set_cursor_visible(visible);
-            self.cursor_visible = visible;
         }
     }
 }

--- a/src/graphics/window/cursor_icon.rs
+++ b/src/graphics/window/cursor_icon.rs
@@ -1,7 +1,7 @@
 use crate::graphics::window::winit;
 use std::convert::TryFrom;
 
-/// TODO
+/// Describes the appearance of the mouse cursor.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum CursorIcon {
     /// The platform-dependent default cursor.

--- a/src/graphics/window/cursor_icon.rs
+++ b/src/graphics/window/cursor_icon.rs
@@ -1,0 +1,37 @@
+use crate::graphics::window::winit;
+
+/// TODO
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CursorIcon {
+    /// The platform-dependent default cursor.
+    Default,
+    /// A simple crosshair.
+    Crosshair,
+    /// A hand (often used to indicate links in web browsers).
+    Hand,
+    /// Hides the cursor.
+    Hidden,
+    /// Indicates something is to be moved.
+    Move,
+}
+
+impl Default for CursorIcon {
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
+impl From<CursorIcon> for winit::window::CursorIcon {
+    fn from(cursor_icon: CursorIcon) -> winit::window::CursorIcon {
+        match cursor_icon {
+            // If the cursor is hidden, it doesn't matter which type it is, so the default makes
+            // the most sense.
+            CursorIcon::Default | CursorIcon::Hidden => {
+                winit::window::CursorIcon::Default
+            }
+            CursorIcon::Crosshair => winit::window::CursorIcon::Crosshair,
+            CursorIcon::Hand => winit::window::CursorIcon::Hand,
+            CursorIcon::Move => winit::window::CursorIcon::Move,
+        }
+    }
+}

--- a/src/graphics/window/cursor_icon.rs
+++ b/src/graphics/window/cursor_icon.rs
@@ -1,4 +1,5 @@
 use crate::graphics::window::winit;
+use std::convert::TryFrom;
 
 /// TODO
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -21,17 +22,18 @@ impl Default for CursorIcon {
     }
 }
 
-impl From<CursorIcon> for winit::window::CursorIcon {
-    fn from(cursor_icon: CursorIcon) -> winit::window::CursorIcon {
+impl TryFrom<CursorIcon> for winit::window::CursorIcon {
+    type Error = ();
+
+    fn try_from(
+        cursor_icon: CursorIcon,
+    ) -> Result<winit::window::CursorIcon, ()> {
         match cursor_icon {
-            // If the cursor is hidden, it doesn't matter which type it is, so the default makes
-            // the most sense.
-            CursorIcon::Default | CursorIcon::Hidden => {
-                winit::window::CursorIcon::Default
-            }
-            CursorIcon::Crosshair => winit::window::CursorIcon::Crosshair,
-            CursorIcon::Hand => winit::window::CursorIcon::Hand,
-            CursorIcon::Move => winit::window::CursorIcon::Move,
+            CursorIcon::Default => Ok(winit::window::CursorIcon::Default),
+            CursorIcon::Crosshair => Ok(winit::window::CursorIcon::Crosshair),
+            CursorIcon::Hand => Ok(winit::window::CursorIcon::Hand),
+            CursorIcon::Hidden => Err(()),
+            CursorIcon::Move => Ok(winit::window::CursorIcon::Move),
         }
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -174,7 +174,7 @@ pub type Panel<'a, Message> = widget::Panel<'a, Message, Renderer>;
 pub type Element<'a, Message> = self::core::Element<'a, Message, Renderer>;
 
 use crate::game::{self, Loop as _};
-use crate::graphics::{Point, Window, WindowSettings};
+use crate::graphics::{CursorIcon, Point, Window, WindowSettings};
 use crate::input::{self, mouse, Input as _};
 use crate::load::Task;
 use crate::ui::core::{Event, Interface, MouseCursor, Renderer as _};
@@ -277,7 +277,8 @@ pub trait UserInterface: Game {
 struct Loop<UI: UserInterface> {
     renderer: UI::Renderer,
     messages: Vec<UI::Message>,
-    mouse_cursor: MouseCursor,
+    game_cursor: CursorIcon,
+    ui_cursor: MouseCursor,
     cache: Option<core::Cache>,
     cursor_position: Point,
     events: Vec<Event>,
@@ -291,7 +292,8 @@ impl<UI: UserInterface> game::Loop<UI> for Loop<UI> {
         Loop {
             renderer,
             messages: Vec::new(),
-            mouse_cursor: MouseCursor::OutOfBounds,
+            game_cursor: CursorIcon::Default,
+            ui_cursor: MouseCursor::OutOfBounds,
             cache: Some(cache),
             cursor_position: Point::new(0.0, 0.0),
             events: Vec::new(),
@@ -338,7 +340,7 @@ impl<UI: UserInterface> game::Loop<UI> for Loop<UI> {
             interface.on_event(event, cursor_position, messages)
         });
 
-        let new_cursor = interface.draw(
+        let new_ui_cursor = interface.draw(
             &mut self.renderer,
             &mut window.frame(),
             cursor_position,
@@ -346,15 +348,28 @@ impl<UI: UserInterface> game::Loop<UI> for Loop<UI> {
 
         self.cache = Some(interface.cache());
 
-        if new_cursor != self.mouse_cursor {
-            if new_cursor == MouseCursor::OutOfBounds {
+        if new_ui_cursor != self.ui_cursor {
+            if new_ui_cursor == MouseCursor::OutOfBounds {
                 input.update(input::Event::Mouse(mouse::Event::CursorReturned));
-            } else if self.mouse_cursor == MouseCursor::OutOfBounds {
+            } else if self.ui_cursor == MouseCursor::OutOfBounds {
                 input.update(input::Event::Mouse(mouse::Event::CursorTaken));
             }
 
-            window.update_cursor(new_cursor.into());
-            self.mouse_cursor = new_cursor;
+            self.ui_cursor = new_ui_cursor;
+        }
+        let new_game_cursor = ui.cursor_icon();
+        if new_game_cursor != self.game_cursor {
+            self.game_cursor = new_game_cursor;
+        }
+
+        // TODO: Only update the cursor if it has changed once `MouseCursor` & `CursorIcon` merges
+        // Use the game cursor if cursor is not on a UI element, use the mouse cursor otherwise
+        if self.ui_cursor == MouseCursor::OutOfBounds {
+            window.set_cursor_visible(self.game_cursor != CursorIcon::Hidden);
+            window.update_cursor(self.game_cursor.into());
+        } else {
+            window.set_cursor_visible(true);
+            window.update_cursor(self.ui_cursor.into());
         }
 
         for message in messages.drain(..) {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -174,11 +174,12 @@ pub type Panel<'a, Message> = widget::Panel<'a, Message, Renderer>;
 pub type Element<'a, Message> = self::core::Element<'a, Message, Renderer>;
 
 use crate::game::{self, Loop as _};
-use crate::graphics::{CursorIcon, Point, Window, WindowSettings};
+use crate::graphics::{Point, Window, WindowSettings};
 use crate::input::{self, mouse, Input as _};
 use crate::load::Task;
 use crate::ui::core::{Event, Interface, MouseCursor, Renderer as _};
 use crate::{Debug, Game, Result};
+use std::convert::TryInto;
 
 /// The user interface of your game.
 ///
@@ -358,11 +359,9 @@ impl<UI: UserInterface> game::Loop<UI> for Loop<UI> {
         // Use the game cursor if cursor is not on a UI element, use the mouse cursor otherwise
         if self.mouse_cursor == MouseCursor::OutOfBounds {
             let game_cursor = ui.cursor_icon();
-            window.set_cursor_visible(game_cursor != CursorIcon::Hidden);
-            window.update_cursor(game_cursor.into());
+            window.update_cursor(game_cursor.try_into().ok());
         } else {
-            window.set_cursor_visible(true);
-            window.update_cursor(self.mouse_cursor.into());
+            window.update_cursor(Some(self.mouse_cursor.into()));
         }
 
         for message in messages.drain(..) {


### PR DESCRIPTION
@hecrj I got stuck on some implementation details & decisions to make for #111, so I thought I'd open a draft PR to make it easier to discuss. The main problem revolves around the following:

When we control the cursor icon through the game trait by updating it every frame, we prevent the system taking over the icon. As an example, if I set the icon to `Default` and then try to `Move` the window in Windows 10, the `Move` icon goes away immediately. That might be what some clients want, but I don't think we should force them into specifying an icon at all times unless they want to.

There are several ways to get around the issue, most of which I think will require us keeping state of the cursor, because as far as I can tell, there is no way to get the current cursor icon from `winit`.

1. In `Game` instead of `fn cursor_icon(&self) -> CursorIcon` we could have `fn cursor_icon(&self, current_icon: CursorIcon) -> CursorIcon` which would let the client decide when and how to update the cursor. It'd provide the knowledge of the current `cursor_icon` which might come in handy in some cases, although I am not sure if it'd be anything common.
2. We could have an `Unchanged` variant or something similar in the `CursorIcon` `enum` and don't update the icon in this case. I am afraid that this might be a bit more confusing then the first option, but it's hard to say.
3. In `Game` instead of `fn cursor_icon(&self) -> CursorIcon` we could have `fn cursor_icon(&self) -> Option<CursorIcon>`. `None` could mean that don't set the `cursor_icon` manually. It'd result in the last cursor icon to remain as is, but would also let the system take over. Without checking the docs, it might be interpreted as `Hidden` which would be bad.

I don't even know how this all connects to `UserInterface` and how the cursor is updated from there. I might be thinking too much over this and just a simple implementation might be fine too, I am not sure. Either way, I'd really appreciate your input on what you think is the best course of action.

---

Notes about the other parts of this WIP PR:
* I don't know if we want to add all the cursor icons from `winit` or not. I was thinking I'd add only a few of them just to get the implementation out and then separately the different variants could be decided. I am totally fine with implementing the variants you might already have in mind.
* Setting cursor icon and visibility separately makes me a little sad 😬 
* `CursorIcon::Hidden` being mapped to the `Default` icon makes me even sadder. If we don't end up keeping track of the state, I think it might be best to use `TryFrom` trait or have a custom function that returns `Option<CursorIcon>` and don't update the cursor if an icon variant doesn't make sense. I also played with having an enum like below, but I am not sure if added complexity is worth it.

```
pub enum CursorIconState {
    Visible(CursorIcon),
    Unchanged,
    Hidden
}
```
* I am leaving the documentation until after the implementation is done to avoid duplicating effort.

---

@hecrj Sorry for the long PR description. I'd appreciate any feedback you might have. (for the code or the questions) Feel free to ignore the notes for now if you want to focus on the main issue.