### PR TITLE
Add project/unproject methods to `Transformation`.

### DIFF
--- a/src/graphics/transformation.rs
+++ b/src/graphics/transformation.rs
@@ -68,12 +68,12 @@ impl Transformation {
     ///
     /// Can be used to convert world-coordinates to screen-coordinates
     /// for a camera, for example.
-    pub fn project(&self, point: Point) -> Point {
-        let inverse_mat = self.0.try_inverse().unwrap();
+    pub fn project(&self, point: Point) -> Option<Point> {
+        let inverse_mat = self.0.try_inverse()?;
 
         let projected = inverse_mat * Vector3::new(point.x, point.y, 1.0);
 
-        Point::new(projected.x, projected.y)
+        Some(Point::new(projected.x, projected.y))
     }
 
     /// Does the inverse projection of a point via this transformation.

--- a/src/graphics/transformation.rs
+++ b/src/graphics/transformation.rs
@@ -76,9 +76,9 @@ impl Transformation {
         Some(Point::new(projected.x, projected.y))
     }
 
-    /// Does the inverse projection of a point via this transformation.
+    /// Applies the inverse projection of a point via this transformation.
     ///
-    /// Can be used to convert world-coordinates to screen-coordinates
+    /// Can be used to convert screen-coordinates to world-coordinates
     /// for a camera, for example.
     pub fn unproject(&self, point: Point) -> Point {
         let unprojected = self.0 * Vector3::new(point.x, point.y, 1.0);

--- a/src/graphics/transformation.rs
+++ b/src/graphics/transformation.rs
@@ -66,8 +66,7 @@ impl Transformation {
 
     /// Projects a point via this transformation.
     ///
-    /// Can be used to convert screen-coordinates to world-coordinates
-    /// for a camera, for example.
+    /// Can be used to convert screen-coordinates to world-coordinates.
     pub fn project(&self, point: Point) -> Option<Point> {
         let inverse_mat = self.0.try_inverse()?;
 
@@ -78,8 +77,7 @@ impl Transformation {
 
     /// Applies the inverse projection of a point via this transformation.
     ///
-    /// Can be used to convert screen-coordinates to world-coordinates
-    /// for a camera, for example.
+    /// Can be used to convert world-coordinates to screen-coordinates.
     pub fn unproject(&self, point: Point) -> Point {
         let unprojected = self.0 * Vector3::new(point.x, point.y, 1.0);
 

--- a/src/graphics/transformation.rs
+++ b/src/graphics/transformation.rs
@@ -1,6 +1,8 @@
 use nalgebra::Matrix3;
+use nalgebra::Vector3;
 use std::ops::Mul;
 
+use crate::graphics::Point;
 use crate::graphics::Vector;
 
 /// A 2D transformation matrix.
@@ -62,6 +64,21 @@ impl Transformation {
     /// You can use this to rotate your camera, for example.
     pub fn rotate(rotation: f32) -> Transformation {
         Transformation(Matrix3::new_rotation(rotation))
+    }
+
+    /// Does the inverse projection of a point via this transformation.
+    ///
+    /// Can be used to convert world-coordinates to screen-coordinates.
+    pub fn inverse(&self) -> Option<Transformation> {
+        Some(Transformation(self.0.try_inverse()?))
+    }
+}
+
+impl Mul<Point> for Transformation {
+    type Output = Point;
+
+    fn mul(self, rhs: Point) -> Point {
+        Point::from((self.0 * Vector3::new(rhs.x, rhs.y, 1.0)).xy())
     }
 }
 

--- a/src/graphics/transformation.rs
+++ b/src/graphics/transformation.rs
@@ -63,6 +63,28 @@ impl Transformation {
     pub fn rotate(rotation: f32) -> Transformation {
         Transformation(Matrix3::new_rotation(rotation))
     }
+
+    /// Projects a point via this transformation.
+    ///
+    /// Can be used to convert world-coordinates to screen-coordinates
+    /// for a camera, for example.
+    pub fn project(&self, point: Point) -> Point {
+        let inverse_mat = self.0.try_inverse().unwrap();
+
+        let projected = inverse_mat * Vector3::new(point.x, point.y, 1.0);
+
+        Point::new(projected.x, projected.y)
+    }
+
+    /// Does the inverse projection of a point via this transformation.
+    ///
+    /// Can be used to convert screen-coordinates to world-coordinates
+    /// for a camera, for example.
+    pub fn unproject(&self, point: Point) -> Point {
+        let unprojected = self.0 * Vector3::new(point.x, point.y, 1.0);
+
+        Point::new(unprojected.x, unprojected.y)
+    }
 }
 
 impl Mul for Transformation {

--- a/src/graphics/transformation.rs
+++ b/src/graphics/transformation.rs
@@ -1,4 +1,4 @@
-use nalgebra::Matrix3;
+use nalgebra::{Matrix3, Vector3};
 use std::ops::Mul;
 
 use crate::graphics::Vector;

--- a/src/graphics/transformation.rs
+++ b/src/graphics/transformation.rs
@@ -66,7 +66,7 @@ impl Transformation {
 
     /// Projects a point via this transformation.
     ///
-    /// Can be used to convert world-coordinates to screen-coordinates
+    /// Can be used to convert screen-coordinates to world-coordinates
     /// for a camera, for example.
     pub fn project(&self, point: Point) -> Option<Point> {
         let inverse_mat = self.0.try_inverse()?;
@@ -78,7 +78,7 @@ impl Transformation {
 
     /// Does the inverse projection of a point via this transformation.
     ///
-    /// Can be used to convert screen-coordinates to world-coordinates
+    /// Can be used to convert world-coordinates to screen-coordinates
     /// for a camera, for example.
     pub fn unproject(&self, point: Point) -> Point {
         let unprojected = self.0 * Vector3::new(point.x, point.y, 1.0);

--- a/src/graphics/transformation.rs
+++ b/src/graphics/transformation.rs
@@ -1,7 +1,7 @@
 use nalgebra::{Matrix3, Vector3};
 use std::ops::Mul;
 
-use crate::graphics::Vector;
+use crate::graphics::{Point, Vector};
 
 /// A 2D transformation matrix.
 ///

--- a/src/graphics/transformation.rs
+++ b/src/graphics/transformation.rs
@@ -66,7 +66,7 @@ impl Transformation {
         Transformation(Matrix3::new_rotation(rotation))
     }
 
-    /// Does the inverse projection of a point via this transformation.
+    /// Attempt to get the inverse of the transform.
     ///
     /// Can be used to convert world-coordinates to screen-coordinates.
     pub fn inverse(&self) -> Option<Transformation> {


### PR DESCRIPTION
## Motivation

I needed a way to project camera coordinates to world coordinates to be able to "pick" tiles using the mouse in a tile based game with a moving camera; In order to do so I needed to project the screen space coordinates into the world using the current `Transformation`.

## Solution

Add the following methods to `coffee::graphics::Transformation`.
```rust
pub fn project(&self, point: Point) -> Point;

pub fn unproject(&self, point: Point) -> Point;
```

## Further Work / Possible Improvements

- [x] ~~Get the inverse matrix in an infallible way?~~
```rust
let inverse_mat = self.0.try_inverse().unwrap();
```

