### PR TITLE
expose set of pressed keys

### DIFF
--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -30,6 +30,11 @@ impl Keyboard {
     pub fn was_key_released(&self, key_code: KeyCode) -> bool {
         self.released_keys.contains(&key_code)
     }
+
+    /// Returns the set of pressed keys.
+    pub fn pressed_keys(&self) -> &HashSet<KeyCode> {
+        &self.pressed_keys
+    }
 }
 
 impl Input for Keyboard {


### PR DESCRIPTION
I wanted to iterate over all currently pressed keys, which the current API does not expose.