### PR TITLE
expose vsync toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ fn main() -> Result<()> {
         resizable: true,
         fullscreen: false,
         maximized: false,
+        vsync: false,
     })
 }
 

--- a/examples/color.rs
+++ b/examples/color.rs
@@ -12,6 +12,7 @@ fn main() -> Result<()> {
         resizable: false,
         fullscreen: false,
         maximized: false,
+        vsync: false,
     })
 }
 

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -16,6 +16,7 @@ pub fn main() -> Result<()> {
         resizable: false,
         fullscreen: false,
         maximized: false,
+        vsync: false,
     })
 }
 

--- a/examples/gamepad.rs
+++ b/examples/gamepad.rs
@@ -14,6 +14,7 @@ fn main() -> Result<()> {
         resizable: false,
         fullscreen: false,
         maximized: false,
+        vsync: false,
     })
 }
 

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -15,6 +15,7 @@ pub fn main() -> Result<()> {
         resizable: false,
         fullscreen: false,
         maximized: false,
+        vsync: false,
     })
 }
 

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -19,6 +19,7 @@ fn main() -> Result<()> {
         resizable: false,
         fullscreen: false,
         maximized: false,
+        vsync: false,
     })
 }
 

--- a/examples/mesh.rs
+++ b/examples/mesh.rs
@@ -19,6 +19,7 @@ fn main() -> Result<()> {
         resizable: false,
         fullscreen: false,
         maximized: false,
+        vsync: false,
     })
 }
 

--- a/examples/particles.rs
+++ b/examples/particles.rs
@@ -21,6 +21,7 @@ fn main() -> Result<()> {
         resizable: false,
         fullscreen: false,
         maximized: false,
+        vsync: false,
     })
 }
 

--- a/examples/progress.rs
+++ b/examples/progress.rs
@@ -15,6 +15,7 @@ pub fn main() -> Result<()> {
         resizable: false,
         fullscreen: false,
         maximized: false,
+        vsync: false,
     })
 }
 

--- a/examples/rectangle.rs
+++ b/examples/rectangle.rs
@@ -11,6 +11,7 @@ fn main() -> coffee::Result<()> {
         resizable: true,
         fullscreen: false,
         maximized: false,
+        vsync: false,
     })
 }
 

--- a/examples/snake.rs
+++ b/examples/snake.rs
@@ -1,7 +1,8 @@
 extern crate coffee;
 
 use coffee::graphics::{
-    Color, Font, Frame, Mesh, Point, Rectangle, Shape, Text, Window, WindowSettings,
+    Color, Font, Frame, Mesh, Point, Rectangle, Shape, Text, Window,
+    WindowSettings,
 };
 use coffee::input::keyboard::KeyCode;
 use coffee::input::{self, keyboard, Input};
@@ -18,6 +19,7 @@ fn main() {
         resizable: false,
         maximized: false,
         fullscreen: false,
+        vsync: false,
     })
     .expect("An error occured while starting the game");
 }

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -15,6 +15,7 @@ fn main() -> Result<()> {
         resizable: false,
         fullscreen: false,
         maximized: false,
+        vsync: false,
     })
 }
 

--- a/src/graphics/backend_gfx/mod.rs
+++ b/src/graphics/backend_gfx/mod.rs
@@ -16,7 +16,7 @@ pub use types::TargetView;
 use gfx::{self, Device};
 use gfx_device_gl as gl;
 
-use crate::graphics::{Color, Transformation};
+use crate::graphics::{Color, Transformation, WindowSettings};
 use crate::Result;
 
 /// A link between your game and a graphics processor.
@@ -40,11 +40,11 @@ pub struct Gpu {
 
 impl Gpu {
     pub(super) fn for_window(
-        builder: winit::window::WindowBuilder,
-        events_loop: &winit::event_loop::EventLoop<()>,
+        settings: WindowSettings,
+        event_loop: &winit::event_loop::EventLoop<()>,
     ) -> Result<(Gpu, Surface)> {
         let (surface, device, mut factory) =
-            Surface::new(builder, events_loop)?;
+            Surface::new(settings, event_loop)?;
 
         let mut encoder: gfx::Encoder<gl::Resources, gl::CommandBuffer> =
             factory.create_command_buffer().into();

--- a/src/graphics/backend_gfx/surface.rs
+++ b/src/graphics/backend_gfx/surface.rs
@@ -1,7 +1,7 @@
 use gfx_device_gl as gl;
 
 use super::{format, Gpu, TargetView};
-use crate::{Error, Result};
+use crate::{graphics::WindowSettings, Error, Result};
 
 pub struct Surface {
     context: glutin::WindowedContext<glutin::PossiblyCurrent>,
@@ -10,7 +10,7 @@ pub struct Surface {
 
 impl Surface {
     pub(super) fn new(
-        builder: winit::window::WindowBuilder,
+        settings: WindowSettings,
         event_loop: &winit::event_loop::EventLoop<()>,
     ) -> Result<(Self, gl::Device, gl::Factory)> {
         let gl_builder = glutin::ContextBuilder::new()
@@ -19,8 +19,9 @@ impl Surface {
             .with_multisampling(0)
             // 24 color bits, 8 alpha bits
             .with_pixel_format(24, 8)
-            .with_vsync(true);
+            .with_vsync(settings.vsync);
 
+        let builder = settings.into_builder(event_loop);
         let (context, device, factory, target, _depth) = init_raw(
             builder,
             gl_builder,

--- a/src/graphics/backend_wgpu/mod.rs
+++ b/src/graphics/backend_wgpu/mod.rs
@@ -12,7 +12,7 @@ pub use texture::Texture;
 pub use triangle::Vertex;
 pub use types::TargetView;
 
-use crate::graphics::{Color, Transformation};
+use crate::graphics::{Color, Transformation, WindowSettings};
 use crate::{Error, Result};
 
 #[allow(missing_debug_implementations)]
@@ -27,9 +27,11 @@ pub struct Gpu {
 
 impl Gpu {
     pub(super) fn for_window(
-        builder: winit::window::WindowBuilder,
+        settings: WindowSettings,
         event_loop: &winit::event_loop::EventLoop<()>,
     ) -> Result<(Gpu, Surface)> {
+        let vsync = settings.vsync;
+        let builder = settings.into_builder(event_loop);
         let window = builder
             .build(event_loop)
             .map_err(|error| Error::WindowCreation(error.to_string()))?;
@@ -57,7 +59,7 @@ impl Gpu {
             (device, queue)
         });
 
-        let surface = Surface::new(window, &device);
+        let surface = Surface::new(window, &device, vsync);
 
         let quad_pipeline = quad::Pipeline::new(&mut device);
         let triangle_pipeline = triangle::Pipeline::new(&mut device);

--- a/src/graphics/window.rs
+++ b/src/graphics/window.rs
@@ -33,8 +33,7 @@ impl Window {
         let (width, height) = settings.size;
         let is_fullscreen = settings.fullscreen;
 
-        let (gpu, surface) =
-            Gpu::for_window(settings.into_builder(event_loop), event_loop)?;
+        let (gpu, surface) = Gpu::for_window(settings, event_loop)?;
 
         Ok(Window {
             is_fullscreen,

--- a/src/graphics/window/settings.rs
+++ b/src/graphics/window/settings.rs
@@ -17,10 +17,13 @@ pub struct Settings {
 
     /// Defines whether or not the window should start maximized.
     pub maximized: bool,
+
+    /// Defines whether or not to enable vsync.
+    pub vsync: bool,
 }
 
 impl Settings {
-    pub(super) fn into_builder(
+    pub(crate) fn into_builder(
         self,
         events_loop: &winit::event_loop::EventLoop<()>,
     ) -> winit::window::WindowBuilder {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@
 //!         resizable: true,
 //!         fullscreen: false,
 //!         maximized: false,
+//!         vsync: false,
 //!     })
 //! }
 //!

--- a/tests/graphics.rs
+++ b/tests/graphics.rs
@@ -23,6 +23,7 @@ fn graphics() -> Result<()> {
         resizable: false,
         fullscreen: false,
         maximized: false,
+        vsync: false,
     })
 }
 


### PR DESCRIPTION
This exposes a toggle to enable/disable vsync.

Some observations:

* Because we don't have a builder for the window preferences, this is a breaking change (though a minor one).
* I'm not sure if it fits with the other options in `WindowSettings`, but it's all I had to work with.
* I chose [`Mailbox`](https://docs.rs/wgpu/0.5.0/wgpu/enum.PresentMode.html#variant.Mailbox) as the non-vsync mode for the non-opengl backends, as it seemed preferable over [`Immediate`](https://docs.rs/wgpu/0.5.0/wgpu/enum.PresentMode.html#variant.Immediate), but I'm happy to change that.