### PR TITLE
add `should_draw` to Game trait

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -173,6 +173,15 @@ pub trait Game {
         false
     }
 
+    /// Returns whether the screen should be drawn.
+    ///
+    /// Use this to limit the amount of drawn frames per second (FPS).
+    ///
+    /// By default, it always returns true.
+    fn should_draw(&self) -> bool {
+        true
+    }
+
     /// Runs the [`Game`] with the given [`WindowSettings`].
     ///
     /// You probably want to call this in your `main` function to run your game!

--- a/src/game/loop.rs
+++ b/src/game/loop.rs
@@ -94,28 +94,31 @@ pub trait Loop<Game: super::Game> {
                 }
             }
             winit::event::Event::RedrawRequested { .. } => {
-                debug.draw_started();
-                game.draw(&mut window.frame(), &timer);
-                debug.draw_finished();
+                if game.should_draw() {
+                    debug.draw_started();
+                    game.draw(&mut window.frame(), &timer);
+                    debug.draw_finished();
 
-                game_loop.after_draw(
-                    &mut game,
-                    &mut input,
-                    &mut window,
-                    &mut debug,
-                );
+                    game_loop.after_draw(
+                        &mut game,
+                        &mut input,
+                        &mut window,
+                        &mut debug,
+                    );
 
-                if debug.is_enabled() {
-                    debug.debug_started();
-                    game.debug(&input, &mut window.frame(), &mut debug);
-                    debug.debug_finished();
+                    if debug.is_enabled() {
+                        debug.debug_started();
+                        game.debug(&input, &mut window.frame(), &mut debug);
+                        debug.debug_finished();
+                    }
+
+                    window.swap_buffers();
+                    debug.frame_finished();
+
+                    debug.frame_started();
+                    window.request_redraw();
                 }
 
-                window.swap_buffers();
-                debug.frame_finished();
-
-                debug.frame_started();
-                window.request_redraw();
                 timer.update();
             }
             winit::event::Event::WindowEvent { event, .. } => match event {


### PR DESCRIPTION
I tried to implement an FPS limit solution in my game by returning early from `Game::draw` if the minimum time between frames wasn't met yet, but noticed that this broke horribly due to Coffee still doing a lot of pre-/post-processing on every draw call.

By exposing `Game::should_draw`, the game can decide when Coffee should trigger another draw. The default return value is `true`, which results in the same behaviour as before this change.

I haven't dug too deep into Coffee yet, but I believe `timer.update()` should still always run? At least anecdotally, for me, this change behaves as expected.